### PR TITLE
Several improvements to the create_rpm.sh script

### DIFF
--- a/packaging/create_rpm.sh
+++ b/packaging/create_rpm.sh
@@ -27,13 +27,20 @@ fi
 
 
 MANAGER_RESOURCES_URL=$1
-BRANCH=${2:-master}
+INSTALL_PIP=${2:-true}
+BRANCH=${3:-master}
 
 print_line "Installing fpm dependencies..."
 sudo yum install -y -q ruby-devel gcc make rpm-build rubygems
 
 print_line "Installing fpm..."
 gem install --no-ri --no-rdoc fpm
+
+if [ ${INSTALL_PIP} = "true" ]; then
+    print_line "Installing pip..."
+    curl -O https://bootstrap.pypa.io/get-pip.py
+    sudo python get-pip.py
+fi
 
 print_line "Installing pex..."
 sudo pip install pex

--- a/packaging/create_rpm.sh
+++ b/packaging/create_rpm.sh
@@ -20,6 +20,12 @@ function print_line() {
   echo -e "$COL_YELLOW $LINE $COL_RESET"
 }
 
+if [ $# -eq 0 ]; then
+    echo "You need to provide a resource URL for the script to work"
+    exit 1
+fi
+
+
 MANAGER_RESOURCES_URL=$1
 BRANCH=${2:-master}
 

--- a/packaging/create_rpm.sh
+++ b/packaging/create_rpm.sh
@@ -25,6 +25,8 @@ if [ $# -eq 0 ]; then
     exit 1
 fi
 
+print_line "Validating user has sudo permissions..."
+sudo -n true
 
 MANAGER_RESOURCES_URL=$1
 INSTALL_PIP=${2:-true}

--- a/packaging/create_rpm.sh
+++ b/packaging/create_rpm.sh
@@ -32,17 +32,26 @@ MANAGER_RESOURCES_URL=$1
 INSTALL_PIP=${2:-true}
 BRANCH=${3:-master}
 
+if [ ${INSTALL_PIP} = "true" ]; then
+    print_line "Installing pip..."
+    curl -O https://bootstrap.pypa.io/get-pip.py
+    sudo python get-pip.py
+else
+    print_line "Validating pip is installed..."
+    set +e
+    pip
+    if [ $? -ne "0" ]; then
+       echo "pip is not installed but is required"
+       exit 1
+    fi
+    set -e
+fi
+
 print_line "Installing fpm dependencies..."
 sudo yum install -y -q ruby-devel gcc make rpm-build rubygems
 
 print_line "Installing fpm..."
 gem install --no-ri --no-rdoc fpm
-
-if [ ${INSTALL_PIP} = "true" ]; then
-    print_line "Installing pip..."
-    curl -O https://bootstrap.pypa.io/get-pip.py
-    sudo python get-pip.py
-fi
 
 print_line "Installing pex..."
 sudo pip install pex

--- a/packaging/provision.sh
+++ b/packaging/provision.sh
@@ -6,7 +6,7 @@ function create_install_rpm() {
 
     curl -L https://raw.githubusercontent.com/cloudify-cosmo/cloudify-manager-install/${CORE_BRANCH}/packaging/create_rpm.sh -o /tmp/create_rpm.sh
     chmod +x /tmp/create_rpm.sh
-    /tmp/create_rpm.sh ${MANAGER_RESOURCES_URL}
+    /tmp/create_rpm.sh ${MANAGER_RESOURCES_URL} false
 }
 
 export CORE_TAG_NAME="4.2"


### PR DESCRIPTION
* Validate user has sudo permissions
* Quit early if the resources URL wasn't provided
* Validate if pip is installed
* Allow installing pip from the script (but don't make it mandatory, as pip may already be installed)