### PR TITLE
Allow generating external certs from `cfy_manager`

### DIFF
--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -49,7 +49,10 @@ from .config import config
 from .logger import get_logger, setup_console_logger
 
 from .utils.files import remove_temp_files
-from .utils.certificates import create_internal_certs
+from .utils.certificates import (
+    create_internal_certs,
+    create_external_certs
+)
 
 logger = get_logger('Main')
 
@@ -181,4 +184,10 @@ def remove(verbose=False):
 
 
 if __name__ == '__main__':
-    argh.dispatch_commands([install, configure, remove, create_internal_certs])
+    argh.dispatch_commands([
+        install,
+        configure,
+        remove,
+        create_internal_certs,
+        create_external_certs
+    ])

--- a/cfy_manager/utils/certificates.py
+++ b/cfy_manager/utils/certificates.py
@@ -260,3 +260,16 @@ def create_internal_certs(manager_ip=None,
         networks,
         filename=metadata
     )
+
+
+@argh.arg('--private-ip', help="The manager's private IP", required=True)
+@argh.arg('--public-ip', help="The manager's public IP", required=True)
+def create_external_certs(private_ip=None, public_ip=None):
+    """
+    Recreate Cloudify Manager's external certificates, based on the public
+    and private IPs
+    """
+    # Note: the function has default values for the arguments, but they
+    # are actually required by argh, so it won't be possible to call this
+    # function without them from the CLI
+    generate_external_ssl_cert(ips=[public_ip, private_ip], cn=public_ip)

--- a/cfy_manager/utils/certificates.py
+++ b/cfy_manager/utils/certificates.py
@@ -128,9 +128,9 @@ def _generate_ssl_certificate(ips,
     :type cert_path: str
     :param key_path: path to save the key for the new certificate to
     :type key_path: str
-    :param sign_cert: path to the signing cert (internal CA by default)
+    :param sign_cert: path to the signing cert (self-signed by default)
     :type sign_cert: str
-    :param sign_key: path to the signing cert's key (internal CA by default)
+    :param sign_key: path to the signing cert's key (self-signed by default)
     :type sign_key: str
     :return: The path to the cert and key files on the manager
     """
@@ -264,12 +264,26 @@ def create_internal_certs(manager_ip=None,
 
 @argh.arg('--private-ip', help="The manager's private IP", required=True)
 @argh.arg('--public-ip', help="The manager's public IP", required=True)
-def create_external_certs(private_ip=None, public_ip=None):
+@argh.arg('--sign-cert', help="Path to the signing cert "
+                              "(self-signed by default)")
+@argh.arg('--sign-key', help="Path to the signing cert's key "
+                             "(self-signed by default)")
+def create_external_certs(private_ip=None,
+                          public_ip=None,
+                          sign_cert=None,
+                          sign_key=None):
     """
     Recreate Cloudify Manager's external certificates, based on the public
     and private IPs
     """
-    # Note: the function has default values for the arguments, but they
+    # Note: the function has default values for the IP arguments, but they
     # are actually required by argh, so it won't be possible to call this
     # function without them from the CLI
-    generate_external_ssl_cert(ips=[public_ip, private_ip], cn=public_ip)
+    _generate_ssl_certificate(
+        ips=[public_ip, private_ip],
+        cn=public_ip,
+        cert_path=const.EXTERNAL_CERT_PATH,
+        key_path=const.EXTERNAL_KEY_PATH,
+        sign_cert=sign_cert,
+        sign_key=sign_key
+    )


### PR DESCRIPTION
This should be useful mostly for development/testing purposes,
because until now, it was impossible to have a proper external
cert when working with image-based managers (those are created
with 127.0.0.1 as the public IP).