### PR TITLE
Several `cfy_manager remove` improvements

### DIFF
--- a/cfy_manager/components/influxdb/influxdb.py
+++ b/cfy_manager/components/influxdb/influxdb.py
@@ -34,6 +34,7 @@ from ...exceptions import ValidationError, BootstrapError
 from ...utils import common
 from ...utils.systemd import systemd
 from ...utils.install import yum_install, yum_remove
+from ...utils.users import delete_service_user, delete_group
 from ...utils.logrotate import set_logrotate, remove_logrotate
 from ...utils.network import wait_for_port, check_http_response
 from ...utils.files import copy_notice, remove_notice, remove_files, temp_copy
@@ -208,4 +209,6 @@ def remove():
     systemd.remove(INFLUXB)
     remove_files([HOME_DIR, LOG_DIR, INIT_D_PATH])
     yum_remove(INFLUXB)
+    delete_group(INFLUXB)
+    delete_service_user(INFLUXB)
     logger.notice('InfluxDB successfully removed')

--- a/cfy_manager/components/influxdb/influxdb.py
+++ b/cfy_manager/components/influxdb/influxdb.py
@@ -209,6 +209,6 @@ def remove():
     systemd.remove(INFLUXB)
     remove_files([HOME_DIR, LOG_DIR, INIT_D_PATH])
     yum_remove(INFLUXB)
-    delete_group(INFLUXB)
     delete_service_user(INFLUXB)
+    delete_group(INFLUXB)
     logger.notice('InfluxDB successfully removed')

--- a/cfy_manager/components/logstash/logstash.py
+++ b/cfy_manager/components/logstash/logstash.py
@@ -31,8 +31,9 @@ from ...utils.files import replace_in_file, get_local_source_path
 from ...utils.files import remove_files, deploy, copy_notice, remove_notice
 
 HOME_DIR = join('/opt', LOGSTASH)
+LOGSTASH_CONF_DIR = join('/etc', LOGSTASH)
 LOG_DIR = join(constants.BASE_LOG_DIR, LOGSTASH)
-REMOTE_CONFIG_PATH = '/etc/logstash/conf.d'
+REMOTE_CONFIG_PATH = join(LOGSTASH_CONF_DIR, 'conf.d')
 UNIT_OVERRIDE_PATH = '/etc/systemd/system/logstash.service.d'
 INIT_D_FILE = '/etc/init.d/logstash'
 
@@ -185,6 +186,6 @@ def remove():
     logger.notice('Removing Logstash...')
     remove_notice(LOGSTASH)
     systemd.remove(LOGSTASH)
-    remove_files([HOME_DIR, LOG_DIR, UNIT_OVERRIDE_PATH])
+    remove_files([HOME_DIR, LOG_DIR, UNIT_OVERRIDE_PATH, LOGSTASH_CONF_DIR])
     yum_remove(LOGSTASH)
     logger.notice('Logstash successfully removed')

--- a/cfy_manager/components/nginx/nginx.py
+++ b/cfy_manager/components/nginx/nginx.py
@@ -29,6 +29,7 @@ from ...utils import common
 from ...utils import certificates
 from ...utils.systemd import systemd
 from ...utils.install import yum_install, yum_remove
+from ...utils.users import delete_service_user, delete_group
 from ...utils.logrotate import set_logrotate, remove_logrotate
 from ...utils.files import remove_files, deploy, copy_notice, remove_notice
 
@@ -319,4 +320,6 @@ def remove():
         UNIT_OVERRIDE_PATH
     ])
     yum_remove(NGINX)
+    delete_service_user(NGINX)
+    delete_group(NGINX)
     logger.notice('NGINX successfully removed')

--- a/cfy_manager/components/postgresql/postgresql.py
+++ b/cfy_manager/components/postgresql/postgresql.py
@@ -192,6 +192,6 @@ def remove():
     files.remove_files([PGSQL_LIB_DIR, PGSQL_USR_DIR, LOG_DIR])
     yum_remove('postgresql95')
     yum_remove('postgresql95-libs')
-    delete_group(POSTGRES_USER)
     delete_service_user(POSTGRES_USER)
+    delete_group(POSTGRES_USER)
     logger.notice('PostgreSQL successfully removed')

--- a/cfy_manager/components/postgresql/postgresql.py
+++ b/cfy_manager/components/postgresql/postgresql.py
@@ -28,6 +28,7 @@ from ...logger import get_logger
 from ...utils import common, files
 from ...utils.systemd import systemd
 from ...utils.install import yum_install, yum_remove
+from ...utils.users import delete_service_user, delete_group
 
 
 SYSTEMD_SERVICE_NAME = 'postgresql-9.5'
@@ -191,4 +192,6 @@ def remove():
     files.remove_files([PGSQL_LIB_DIR, PGSQL_USR_DIR, LOG_DIR])
     yum_remove('postgresql95')
     yum_remove('postgresql95-libs')
+    delete_group(POSTGRES_USER)
+    delete_service_user(POSTGRES_USER)
     logger.notice('PostgreSQL successfully removed')

--- a/cfy_manager/components/rabbitmq/rabbitmq.py
+++ b/cfy_manager/components/rabbitmq/rabbitmq.py
@@ -248,6 +248,6 @@ def remove():
         join('/var/log', RABBITMQ)
     ])
     yum_remove('erlang')
-    delete_group(RABBITMQ)
     delete_service_user(RABBITMQ)
+    delete_group(RABBITMQ)
     logger.notice('RabbitMQ successfully removed')

--- a/cfy_manager/components/rabbitmq/rabbitmq.py
+++ b/cfy_manager/components/rabbitmq/rabbitmq.py
@@ -28,6 +28,7 @@ from ...exceptions import ValidationError, NetworkError
 from ...utils.systemd import systemd
 from ...utils.install import yum_install, yum_remove
 from ...utils.network import wait_for_port, is_port_open
+from ...utils.users import delete_service_user, delete_group
 from ...utils.logrotate import set_logrotate, remove_logrotate
 from ...utils.common import sudo, mkdir, chown, remove as remove_file
 from ...utils.files import copy_notice, remove_notice, remove_files, deploy
@@ -247,4 +248,6 @@ def remove():
         join('/var/log', RABBITMQ)
     ])
     yum_remove('erlang')
+    delete_group(RABBITMQ)
+    delete_service_user(RABBITMQ)
     logger.notice('RabbitMQ successfully removed')

--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -46,6 +46,7 @@ from .components.service_names import MANAGER
 from .components import SECURITY, PRIVATE_IP, PUBLIC_IP, ADMIN_PASSWORD
 
 from .config import config
+from .exceptions import BootstrapError
 from .logger import get_logger, setup_console_logger
 
 from .utils.files import remove_temp_files
@@ -169,10 +170,14 @@ def configure(verbose=False,
     _print_time()
 
 
-def remove(verbose=False):
+def remove(verbose=False, force=False):
     """ Uninstall Cloudify Manager """
 
     _load_config_and_logger(verbose)
+    if not force:
+        raise BootstrapError(
+            'The --force flag must be passed to `cfy_manager remove`'
+        )
 
     logger.notice('Removing Cloudify Manager...')
 

--- a/packaging/create_rpm.sh
+++ b/packaging/create_rpm.sh
@@ -93,7 +93,7 @@ print_line "Creating rpm..."
 # --after-install: A script to run after yum install
 # PATH_1=PATH_2: After yum install, move the file in PATH_1 to PATH_2
 # cloudify-manager-install: The directory from which the rpm will be created
-fpm -s dir -t rpm -n cloudify-manager-install --force ${VERSION:+ -v "${VERSION}"} ${PRERELEASE:+ --iteration "${PRERELEASE}"} --after-install ./tmp-install-rpm/install.sh ./tmp-install-rpm/cfy_manager=/usr/bin/cfy_manager ./tmp-install-rpm/cloudify-manager-install=/opt
+fpm -s dir -t rpm -n cloudify-manager-install --force ${VERSION:+ -v "${VERSION}"} ${PRERELEASE:+ --iteration "${PRERELEASE}"} --after-install ./tmp-install-rpm/install.sh --config-files /opt/cloudify-manager-install/config.yaml ./tmp-install-rpm/cfy_manager=/usr/bin/cfy_manager ./tmp-install-rpm/cloudify-manager-install=/opt
 
 print_line "Cleaning up..."
 rm -rf tmp-install-rpm


### PR DESCRIPTION
1. Don't delete the config.yaml file - mark is as an RPM config, which leaves a `config.yaml.rpmsave` file after `yum remove`.
2. Add a required `--force` flag.
3. Remove several users (like we did in the old teardown)