### PR TITLE
Raise an error if OpenSSL version is smaller than 1.0.2

### DIFF
--- a/cfy_manager/components/validations.py
+++ b/cfy_manager/components/validations.py
@@ -141,11 +141,10 @@ def _validate_openssl_version():
         )
         return
 
-    # The output should look like: "LibreSSL 2.2.7"
+    # The output should look like: "LibreSSL 2.2.7" or "OpenSSL 1.0.2k-fips"
     version = output.split()[1]
     if LooseVersion(version) < LooseVersion(required_version):
-        # TODO: This should be an error, after the image is fixed
-        logger.warning(
+        _errors.append(
             'Cloudify Manager requires OpenSSL {0}, current version: {1}'
             ''.format(required_version, version)
         )


### PR DESCRIPTION
Otherwise, the `nginx` installation will fail, and we want to error out as soon as possible.