### PR TITLE
Separate entry points for commands with argh

### DIFF
--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -17,6 +17,7 @@
 import sys
 import argh
 from time import time
+from functools import wraps
 from traceback import format_exception
 
 from .components import cli
@@ -186,6 +187,18 @@ def remove(verbose=False, force=False):
 
     logger.notice('Cloudify Manager successfully removed!')
     _print_time()
+
+
+def dispatch_argh(func):
+    @wraps(func)
+    def _inner():
+        return argh.dispatch_command(func)
+    return _inner
+
+# entry points for console_scripts
+install_command = dispatch_argh(install)
+configure_command = dispatch_argh(configure)
+remove_command = dispatch_argh(remove)
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -45,9 +45,9 @@ setup(
     description='Local install of a cloudify manager',
     entry_points={
         'console_scripts': [
-            'cfy_install = cfy_manager.main:install',
-            'cfy_remove = cfy_manager.main:remove',
-            'cfy_config = cfy_manager.main:configure'
+            'cfy_install = cfy_manager.main:install_command',
+            'cfy_remove = cfy_manager.main:remove_command',
+            'cfy_config = cfy_manager.main:configure_command'
         ]
     },
     zip_safe=False,


### PR DESCRIPTION
Simply using an entry point of eg. `cfy_manager.main:install` won't
use argh, and so will prevent passing in command-line options.
Instead, we use argh.dispatch_command with each entry point, using
a wrapper function.