### PR TITLE
CFY-7656 Always convert a CA certificate to pkcs12

### DIFF
--- a/cfy_manager/components/nginx/nginx.py
+++ b/cfy_manager/components/nginx/nginx.py
@@ -124,6 +124,7 @@ def _handle_ca_cert():
         certificates.generate_ca_cert()
         has_ca_key = True
 
+    certificates.store_pkcs12_cert()
     return has_ca_key
 
 

--- a/cfy_manager/utils/certificates.py
+++ b/cfy_manager/utils/certificates.py
@@ -212,6 +212,12 @@ def generate_ca_cert():
         '-out', const.CA_CERT_PATH,
         '-keyout', const.CA_KEY_PATH
     ])
+    logger.debug('Generated CA certificate: {0} and key: {1}'.format(
+        const.CA_CERT_PATH, const.CA_KEY_PATH
+    ))
+
+
+def store_pkcs12_cert():
     # PKCS12 file required for riemann due to JVM
     # While we don't really want the private key in there, not having it
     # causes failures
@@ -226,12 +232,9 @@ def generate_ca_cert():
         'openssl', 'pkcs12', '-export',
         '-out', pkcs12_path,
         '-in', const.CA_CERT_PATH,
-        '-inkey', const.CA_KEY_PATH,
         '-password', 'pass:cloudify',
+        '-nokeys'
     ])
-    logger.debug('Generated CA certificate: {0} and key: {1}'.format(
-        const.CA_CERT_PATH, const.CA_KEY_PATH
-    ))
 
 
 @argh.arg('--metadata',


### PR DESCRIPTION
Whether the CA cert was provided by the user or generated, it must
always be also copied to a PKCS12 form.
That PKCS12 bundle will only be used for verifying requests, and it
must not contain the private key (which might not even be available
in case of a user-provided CA cert).