### PR TITLE
CFY-7684 Preserve configuration between runs of install/configure

### DIFF
--- a/cfy_manager/config.py
+++ b/cfy_manager/config.py
@@ -13,10 +13,11 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
-import yaml
+from ruamel import yaml
+from ruamel.yaml.error import YAMLError
+
 import collections
 from os.path import isfile
-from yaml.parser import ParserError
 
 from .exceptions import InputError
 from .constants import USER_CONFIG_PATH, DEFAULT_CONFIG_PATH
@@ -59,8 +60,8 @@ class Config(dict):
     def _load_yaml(path_to_yaml):
         with open(path_to_yaml, 'r') as f:
             try:
-                return yaml.load(f)
-            except ParserError as e:
+                return yaml.round_trip_load(f)
+            except YAMLError as e:
                 raise InputError(
                     'User config file {0} is not a properly formatted '
                     'YAML file:\n{1}'.format(path_to_yaml, e)

--- a/cfy_manager/config.py
+++ b/cfy_manager/config.py
@@ -15,6 +15,7 @@
 
 from ruamel.yaml import YAML
 from ruamel.yaml.error import YAMLError
+from ruamel.yaml.comments import CommentedMap
 
 import collections
 from os.path import isfile
@@ -43,11 +44,8 @@ def dict_merge(dct, merge_dct):
             dct[k] = merge_dct[k]
 
 
-class Config(dict):
+class Config(CommentedMap):
     TEMP_PATHS = 'temp_paths_to_remove'
-
-    def __init__(self, *args, **kwargs):
-        super(Config, self).__init__(*args, **kwargs)
 
     def _load_defaults_config(self):
         default_config = self._load_yaml(DEFAULT_CONFIG_PATH)
@@ -75,7 +73,7 @@ class Config(dict):
         self.pop(self.TEMP_PATHS, None)
         with open(USER_CONFIG_PATH, 'w') as f:
             try:
-                yaml.dump(dict(self), f)
+                yaml.dump(CommentedMap(self, relax=True), f)
             except YAMLError as e:
                 raise BootstrapError(
                     'Could not dump config to {0}:\n{1}'.format(

--- a/cfy_manager/config.py
+++ b/cfy_manager/config.py
@@ -13,7 +13,7 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
-from ruamel import yaml
+from ruamel.yaml import YAML
 from ruamel.yaml.error import YAMLError
 
 import collections
@@ -21,6 +21,8 @@ from os.path import isfile
 
 from .exceptions import InputError, BootstrapError
 from .constants import USER_CONFIG_PATH, DEFAULT_CONFIG_PATH
+
+yaml = YAML()
 
 
 def dict_merge(dct, merge_dct):
@@ -62,7 +64,7 @@ class Config(dict):
     def _load_yaml(path_to_yaml):
         with open(path_to_yaml, 'r') as f:
             try:
-                return yaml.round_trip_load(f)
+                return yaml.load(f)
             except YAMLError as e:
                 raise InputError(
                     'User config file {0} is not a properly formatted '
@@ -70,10 +72,10 @@ class Config(dict):
                 )
 
     def dump_config(self):
-        self.pop(self.TEMP_PATHS)
+        self.pop(self.TEMP_PATHS, None)
         with open(USER_CONFIG_PATH, 'w') as f:
             try:
-                yaml.round_trip_dump(self, f)
+                yaml.dump(dict(self), f)
             except YAMLError as e:
                 raise BootstrapError(
                     'Could not dump config to {0}:\n{1}'.format(

--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -128,6 +128,13 @@ def _print_finish_message():
     logger.notice('#' * 50)
 
 
+def _finish_configuration():
+    remove_temp_files()
+    _print_finish_message()
+    _print_time()
+    config.dump_config()
+
+
 def install(verbose=False,
             private_ip=None,
             public_ip=None,
@@ -143,10 +150,8 @@ def install(verbose=False,
     for component in COMPONENTS:
         component.install()
 
-    remove_temp_files()
     logger.notice('Cloudify Manager successfully installed!')
-    _print_finish_message()
-    _print_time()
+    _finish_configuration()
 
 
 def configure(verbose=False,
@@ -164,10 +169,8 @@ def configure(verbose=False,
     for component in COMPONENTS:
         component.configure()
 
-    remove_temp_files()
     logger.notice('Cloudify Manager successfully configured!')
-    _print_finish_message()
-    _print_time()
+    _finish_configuration()
 
 
 def remove(verbose=False, force=False):

--- a/packaging/create_rpm
+++ b/packaging/create_rpm
@@ -392,6 +392,8 @@ def install_dependencies():
         'rubygems',
         # Requirements for this script
         'git',
+        # Requirements for building the python package
+        'python-devel',
     ]
     exit_helpfully_on_failure(
         command=install_rpms,

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     zip_safe=False,
     package_data={'': extra_files},
     install_requires=[
-        'PyYAML==3.10',
+        'ruamel.yaml==0.15.35',
         'Jinja2==2.7.2',
         'argh==0.26.2'
     ]


### PR DESCRIPTION
The idea here is that some arguments may be passed via the command line (like the IPs) or generated during the configuration process (like the admin password), so it makes sense to preserve those in the config file, in order to be able to rerun the configuration/installation with the same values without having to provide them again (or, in the case of generation, without having to keep them elsewhere).