### PR TITLE
CFY-7710 Hide nginx version in the Server header

### DIFF
--- a/cfy_manager/components/nginx/config/nginx.conf
+++ b/cfy_manager/components/nginx/config/nginx.conf
@@ -12,6 +12,7 @@ events {
 
 
 http {
+    server_tokens off;
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 


### PR DESCRIPTION
No real reason to display the nginx version, and it just makes it easier for automated vulnerability scanners to exploit our system.