### PR TITLE
CFY-7703 Choose ciphers used by nginx and rabbitmq

### DIFF
--- a/cfy_manager/components/nginx/config/nginx.conf
+++ b/cfy_manager/components/nginx/config/nginx.conf
@@ -21,6 +21,8 @@ http {
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
     access_log  /var/log/cloudify/nginx/access.log  main;
+    ssl_prefer_server_ciphers On;
+    ssl_ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS;
 
     sendfile        on;
 

--- a/cfy_manager/components/rabbitmq/config/rabbitmq.config
+++ b/cfy_manager/components/rabbitmq/config/rabbitmq.config
@@ -6,7 +6,17 @@
            {ssl_options, [{cacertfile,"/etc/cloudify/ssl/cloudify_internal_ca_cert.pem"},
                           {certfile,  "/etc/cloudify/ssl/cloudify_internal_cert.pem"},
                           {keyfile,   "/etc/cloudify/ssl/cloudify_internal_key.pem"},
-                          {versions, ['tlsv1.2', 'tlsv1.1']}
+                          {versions, ['tlsv1.2', 'tlsv1.1']},
+                          {ciphers, [
+                                {ecdhe_ecdsa,aes_256_cbc,sha384},
+                                {ecdhe_rsa,aes_256_cbc,sha384},
+                                {ecdh_ecdsa,aes_256_cbc,sha384},
+                                {ecdh_rsa,aes_256_cbc,sha384},
+                                {ecdhe_ecdsa,aes_128_cbc,sha256},
+                                {ecdhe_rsa,aes_128_cbc,sha256},
+                                {ecdh_ecdsa,aes_128_cbc,sha256},
+                                {ecdh_rsa,aes_128_cbc,sha256}
+                          ]}
                          ]}
  ]},
  {rabbitmq_management, [{load_definitions, "/etc/rabbitmq/definitions.json"}]}


### PR DESCRIPTION
Disallow use of old, insecure ones.