### PR TITLE
Revert "When uninstalling, also remove cloudify-premium"

### DIFF
--- a/cfy_manager/components/restservice/restservice.py
+++ b/cfy_manager/components/restservice/restservice.py
@@ -208,9 +208,6 @@ def _remove_files():
     # Removing the RPM before recreating /opt/manager/resources, because
     # yum remove will delete this folder
     yum_remove('cloudify-rest-service')
-    # cloudify-premium will not have been installed on community builds,
-    # so expect a possible failure in this call
-    yum_remove('cloudify-premium', ignore_failures=True)
 
     # Recreate /opt/manager/resources and move the spec files back in
     common.mkdir(constants.MANAGER_RESOURCES_HOME)


### PR DESCRIPTION
Reverts cloudify-cosmo/cloudify-manager-install#86

This isn't actually needed, because removing rest-service also removes premium,
because rest-service is a dependency of premium