### PR TITLE
Sign external certificates with the CA cert/key

### DIFF
--- a/cfy_manager/components/cli/cli.py
+++ b/cfy_manager/components/cli/cli.py
@@ -23,7 +23,7 @@ from ...config import config
 from ...logger import get_logger
 
 from ...utils import common
-from ...constants import EXTERNAL_CERT_PATH
+from ...constants import CA_CERT_PATH
 from ...utils.install import yum_install, yum_remove
 
 
@@ -61,7 +61,7 @@ def _configure():
     set_cmd = [
         'cfy', 'profiles', 'set', '-u', username,
         '-p', password, '-t', 'default_tenant',
-        '-c', EXTERNAL_CERT_PATH, '--ssl', ssl_enabled,
+        '-c', CA_CERT_PATH, '--ssl', ssl_enabled,
         '--skip-credentials-validation'
     ]
     logger.info('Setting CLI for default user...')

--- a/cfy_manager/utils/certificates.py
+++ b/cfy_manager/utils/certificates.py
@@ -199,7 +199,9 @@ def generate_external_ssl_cert(ips, cn):
         ips,
         cn,
         const.EXTERNAL_CERT_PATH,
-        const.EXTERNAL_KEY_PATH
+        const.EXTERNAL_KEY_PATH,
+        sign_cert=const.CA_CERT_PATH,
+        sign_key=const.CA_KEY_PATH
     )
 
 


### PR DESCRIPTION
This should allow the users to pass a single CA cert/key pair as the input for the installation and distribute the CA cert to the endpoints (UI/CLI). This should make working in HA clusters much simpler for the users.