### PR TITLE
CFY-7559 Return 404 on wrong API URLs

### DIFF
--- a/cfy_manager/components/nginx/config/rest-location.cloudify
+++ b/cfy_manager/components/nginx/config/rest-location.cloudify
@@ -1,4 +1,4 @@
-location ~ ^/api/v(1|2|2\.1|3|3\.1)/(blueprints|executions|deployments|nodes|events|search|status|provider|node-instances|version|evaluate|deployment-modifications|tokens|plugins|snapshots|maintenance|deployment-updates|tenants|user-groups|user|users|cluster|file-server-auth|ldap|secrets|ssl|config) {
+location ~ ^/api/v(1|2|2\.1|3|3\.1)/(blueprints|executions|deployments|nodes|events|search|status|provider|node-instances|version|evaluate|deployment-modifications|tokens|plugins|snapshots|maintenance|deployment-updates|tenants|user-groups|user|users|cluster|file-server-auth|ldap|secrets|ssl|config)(/.*)?$ {
     proxy_pass         http://cloudify-rest;
     proxy_redirect     off;
 

--- a/cfy_manager/components/nginx/config/rest-location.cloudify
+++ b/cfy_manager/components/nginx/config/rest-location.cloudify
@@ -21,3 +21,7 @@ location ~ ^/api/version {
 location ~ ^/(blueprints|snapshots|executions|deployments|nodes|events|search|status|provider|node-instances|version|evaluate|deployment-modifications|tokens)(.*)$ {
    rewrite ^/(blueprints|snapshots|executions|deployments|nodes|events|search|status|provider|node-instances|version|evaluate|deployment-modifications|tokens)(.*)$ /api/v1/$1$2;
 }
+
+location /api {
+    return 404;
+}


### PR DESCRIPTION
This makes requests to `/api/v3/usersxxx` or `/api/v3/nonexistent` not
proxy to the API at all, and return a 404 instead.