### PR TITLE
Restservice: install premium separately

### DIFF
--- a/cfy_manager/components/restservice/restservice.py
+++ b/cfy_manager/components/restservice/restservice.py
@@ -207,7 +207,9 @@ def _remove_files():
 
 def install():
     logger.notice('Installing Rest Service...')
-    for source in config[RESTSERVICE][SOURCES].values():
+    for label, source in config[RESTSERVICE][SOURCES].items():
+        if label == 'premium_source_url':
+            continue
         yum_install(source)
 
     premium_source_url = config[RESTSERVICE][SOURCES]['premium_source_url']

--- a/cfy_manager/components/restservice/restservice.py
+++ b/cfy_manager/components/restservice/restservice.py
@@ -207,10 +207,8 @@ def _remove_files():
 
 def install():
     logger.notice('Installing Rest Service...')
-    for label, source in config[RESTSERVICE][SOURCES].items():
-        if label == 'premium_source_url':
-            continue
-        yum_install(source)
+    yum_install(config[RESTSERVICE][SOURCES]['restservice_source_url'])
+    yum_install(config[RESTSERVICE][SOURCES]['agents_source_url'])
 
     premium_source_url = config[RESTSERVICE][SOURCES]['premium_source_url']
     try:


### PR DESCRIPTION
cloudify-premium must be installed separately, because it might not
be available (in a community edition)