### PR TITLE
CFY-7926 Use full path for getenforce

### DIFF
--- a/cfy_manager/components/manager/manager.py
+++ b/cfy_manager/components/manager/manager.py
@@ -60,7 +60,7 @@ def _create_sudoers_file_and_disable_sudo_requiretty():
 
 def _get_selinux_state():
     try:
-        return subprocess.check_output('getenforce').rstrip('\n\r')
+        return subprocess.check_output(['/usr/sbin/getenforce']).rstrip('\n\r')
     except OSError:
         logger.warning('SELinux is not installed')
         return None

--- a/cfy_manager/components/manager/manager.py
+++ b/cfy_manager/components/manager/manager.py
@@ -61,8 +61,8 @@ def _create_sudoers_file_and_disable_sudo_requiretty():
 def _get_selinux_state():
     try:
         return subprocess.check_output(['/usr/sbin/getenforce']).rstrip('\n\r')
-    except OSError:
-        logger.warning('SELinux is not installed', exc_info=True)
+    except OSError as e:
+        logger.warning('SELinux is not installed ({0})'.format(e))
         return None
 
 

--- a/cfy_manager/components/manager/manager.py
+++ b/cfy_manager/components/manager/manager.py
@@ -62,7 +62,7 @@ def _get_selinux_state():
     try:
         return subprocess.check_output(['/usr/sbin/getenforce']).rstrip('\n\r')
     except OSError:
-        logger.warning('SELinux is not installed')
+        logger.warning('SELinux is not installed', exc_info=True)
         return None
 
 


### PR DESCRIPTION
`/usr/sbin` is not on the PATH if we're not using a login shell, so without this,
eg. `$ ssh centos@manager cfy_manager install` will break because `getenforce`
will not be found