### PR TITLE
CY-164 Logstash: use SSL to connect to rabbitmq

### DIFF
--- a/cfy_manager/components/globals.py
+++ b/cfy_manager/components/globals.py
@@ -91,6 +91,7 @@ def _set_constant_config():
     const_conf['internal_key_path'] = constants.INTERNAL_KEY_PATH
     const_conf['external_cert_path'] = constants.EXTERNAL_CERT_PATH
     const_conf['external_key_path'] = constants.EXTERNAL_KEY_PATH
+    const_conf['pkcs12_cert_path'] = constants.CA_CERT_PATH
 
     const_conf['internal_rest_port'] = constants.INTERNAL_REST_PORT
 

--- a/cfy_manager/components/logstash/config/logstash.conf
+++ b/cfy_manager/components/logstash/config/logstash.conf
@@ -8,22 +8,28 @@ input {
         queue => "cloudify-logs"
         exchange => "cloudify-logs"
         host => "{{ rabbitmq.endpoint_ip }}"
-        port => "5672"
+        port => "5671"
         durable => "true"
         exclusive => "false"
         user => "{{ rabbitmq.username }}"
         password => "{{ rabbitmq.password }}"
+        ssl => true
+        ssl_certificate_path => "{{ constants.pkcs12_cert_path }}""
+        ssl_certificate_password => "cloudify"
     }
     rabbitmq {
         tags => ["event"]
         queue => "cloudify-events"
         exchange => "cloudify-events"
         host => "{{ rabbitmq.endpoint_ip }}"
-        port => "5672"
+        port => "5671"
         durable => "true"
         exclusive => "false"
         user => "{{ rabbitmq.username }}"
         password => "{{ rabbitmq.password }}"
+        ssl => true
+        ssl_certificate_path => "{{ constants.pkcs12_cert_path }}""
+        ssl_certificate_password => "cloudify"
     }
     # This allows us to verify that logstash is running.
     # it is non-functional for the manager and will be removed in the future.


### PR DESCRIPTION
Blocked by CY-163, don't merge before rabbitmq input plugin is
upgraded to a version that actually supports these settings