### PR TITLE
CY-96 Add a separate amqp_management_host to rest config

### DIFF
--- a/cfy_manager/components/restservice/config/cloudify-rest.conf
+++ b/cfy_manager/components/restservice/config/cloudify-rest.conf
@@ -15,6 +15,7 @@
     ldap_is_active_directory: {{ restservice.ldap.is_active_directory }},
     ldap_dn_extra: '{{ restservice.ldap.dn_extra }}',
     amqp_host: '{{ rabbitmq.endpoint_ip }}',
+    amqp_management_host: '{{ rabbitmq.management_endpoint_ip }}',
     amqp_username: '{{ rabbitmq.username }}',
     amqp_password: '{{ rabbitmq.password }}',
     amqp_ca_path: '{{ rabbitmq.broker_cert_path }}',


### PR DESCRIPTION
Now that the management API endpoint ip can be different,
it must also be passed separately