### PR TITLE
CY-244 Fix the restore of stage files

### DIFF
--- a/cfy_manager/components/stage/scripts/restore-snapshot.py
+++ b/cfy_manager/components/stage/scripts/restore-snapshot.py
@@ -15,8 +15,8 @@
 #  * limitations under the License.
 
 import os
-import shutil
 import argparse
+from distutils.dir_util import copy_tree
 
 HOME_DIR = "{{ stage.home_dir }}"
 
@@ -26,11 +26,9 @@ def _restore(snapshot_root, override=False):
         destination = os.path.join(HOME_DIR, folder)
         if not override:
             destination = os.path.join(destination, 'from_snapshot')
-        if os.path.exists(destination):
-            shutil.rmtree(destination)
         # in old snapshots, userData might not exist
         try:
-            shutil.copytree(os.path.join(snapshot_root, folder), destination)
+            copy_tree(os.path.join(snapshot_root, folder), destination)
         except OSError:
             pass
 


### PR DESCRIPTION
* The restore was deleting the directory /opt/cloudify-stage/conf and then copied the one from the snapshot

* Now the files are being copied from the snapshot directory so existing files are not being removed