### PR TITLE
Adding Diamond to create caravan

### DIFF
--- a/packaging/create_caravan.py
+++ b/packaging/create_caravan.py
@@ -17,7 +17,8 @@ PLUGINS_TO_BUNDLE = ['vSphere',
                      'AWS SDK',
                      'Azure',
                      'Kubernetes',
-                     'Utilities']
+                     'Utilities',
+                     'Diamond']
 
 
 DISTROS_TO_BUNDLE = ['Centos Core', 'Redhat Maipo']


### PR DESCRIPTION
It is fine that we will be moving away from Diamond - but until the replacement is GA, we should allow users to use it - since a lot of examples still do, particularly pre-4.3.2.