### PR TITLE
Fix for getting all the results from the rest client

### DIFF
--- a/cfy_manager/components/usage_collector/scripts/collect_cloudify_usage.py
+++ b/cfy_manager/components/usage_collector/scripts/collect_cloudify_usage.py
@@ -87,21 +87,20 @@ def _collect_system_data(data):
 def _collect_cloudify_data(data):
     with _get_storage_manager() as sm:
         plugins_list = [plugin.package_name.lower()
-                        for plugin in sm.list(models.Plugin, all_tenants=True)]
+                        for plugin in sm.list(models.Plugin,
+                                              all_tenants=True,
+                                              get_all_results=True)]
+
         data['cloudify_usage'] = {
-            'tenants_count': len(sm.list(models.Tenant)),
-            'users_count': len(sm.list(models.User)),
-            'usergroups_count': len(sm.list(models.Group)),
-            'blueprints_count': len(sm.list(models.Blueprint,
-                                            all_tenants=True)),
-            'deployments_count': len(sm.list(models.Deployment,
-                                             all_tenants=True)),
-            'executions_count': len(sm.list(models.Execution,
-                                            all_tenants=True)),
-            'secrets_count': len(sm.list(models.Secret, all_tenants=True)),
-            'nodes_count': len(sm.list(models.Node, all_tenants=True)),
-            'node_instances_count': len(sm.list(models.NodeInstance,
-                                                all_tenants=True)),
+            'tenants_count': sm.count(models.Tenant),
+            'users_count': sm.count(models.User),
+            'usergroups_count': sm.count(models.Group),
+            'blueprints_count': sm.count(models.Blueprint),
+            'deployments_count': sm.count(models.Deployment),
+            'executions_count': sm.count(models.Execution),
+            'secrets_count': sm.count(models.Secret),
+            'nodes_count': sm.count(models.Node),
+            'node_instances_count': sm.count(models.NodeInstance),
             'plugins_count': len(plugins_list),
             'aws_plugin': _find_substring_in_list(plugins_list, 'aws'),
             'azure_plugin': _find_substring_in_list(plugins_list, 'azure'),


### PR DESCRIPTION
* The default behavior of our storage manager `list` limits the result size to 1000 records

* When using `get_all_results` parameter it ignores this limitation

* When using the `count` function it ignores the limit and returns the number of the records