### PR TITLE
Removed unused variable

### DIFF
--- a/cfy_manager/components/restservice/config/cloudify-restservice
+++ b/cfy_manager/components/restservice/config/cloudify-restservice
@@ -8,7 +8,6 @@ REST_PORT={{ restservice.port }}
 
 # gunicorn configuration
 WORKER_COUNT={{ restservice.gunicorn.worker_count }}
-MAX_WORKER_COUNT={{ restservice.gunicorn.max_worker_count }}
 
 GUNICORN_WORKER_COUNT={{ restservice.gunicorn.worker_count }}
 GUNICORN_MAX_REQUESTS={{ restservice.gunicorn.max_requests }}


### PR DESCRIPTION
This environment variable isn't used anywhere at runtime. It's there by mistake.