### PR TITLE
CY-531: only allow ciphers considered Advanced+ and Advanced by OWASP

### DIFF
--- a/cfy_manager/components/nginx/config/nginx.conf
+++ b/cfy_manager/components/nginx/config/nginx.conf
@@ -21,7 +21,11 @@ http {
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
     access_log  /var/log/cloudify/nginx/access.log  main;
+
     ssl_protocols TLSv1.2;
+    ssl_prefer_server_ciphers on;
+    ssl_ciphers HIGH:!aNULL:!MD5:!AES256-GCM-SHA384:!AES256-SHA256:!AES256-SHA:!CAMELLIA256-SHA:!ECDHE-RSA-AES256-SHA:!ECDHE-RSA-AES128-SHA:!AES128-GCM-SHA256:!AES128-SHA256:!AES128-SHA:!CAMELLIA128-SHA;
+
     sendfile        on;
 
     keepalive_timeout  65;


### PR DESCRIPTION
The ciphers included in the `HIGH` nginx category include ciphers that aren't considered `Advanced+` and `Advanced` by OWASP, so I removed those.

The intersection between the ciphers that nginx supports, and the ciphers considered `Advanced+` and `Advanced` by OWASP, ends up yielding 4 ciphers only:

* `ECDHE-RSA-AES256-GCM-SHA384`
* `ECDHE-RSA-AES256-SHA384`
* `ECDHE-RSA-AES128-GCM-SHA256`
* `ECDHE-RSA-AES128-SHA256`