### PR TITLE
CY-546: move run dir to a location independent of legacy.conf

### DIFF
--- a/cfy_manager/components/manager/config/cloudify.conf
+++ b/cfy_manager/components/manager/config/cloudify.conf
@@ -1,2 +1,2 @@
-# Cloudify's lock directory
-D /var/lock/cloudify 0755 cfyuser cfyuser - -
+# Cloudify's lock directory.
+D /run/cloudify.lock 0755 cfyuser cfyuser - -

--- a/cfy_manager/constants.py
+++ b/cfy_manager/constants.py
@@ -28,7 +28,7 @@ CLOUDIFY_SUDOERS_FILE = join(SUDOERS_INCLUDE_DIR, CLOUDIFY_USER)
 INITIAL_INSTALL_FILE = join(CLOUDIFY_HOME_DIR, '.install')
 
 # Must be identical to COMMON_LOCK_DIR in cloudify-premium/ha/utils.py
-COMMON_LOCK_DIR = '/var/lock/cloudify'
+COMMON_LOCK_DIR = '/run/cloudify.lock'
 BASE_RESOURCES_PATH = '/opt/cloudify'
 CLOUDIFY_SOURCES_PATH = join(BASE_RESOURCES_PATH, 'sources')
 MANAGER_RESOURCES_HOME = '/opt/manager/resources'


### PR DESCRIPTION
Using `/run/lock/<subdir>` (or `/var/lock/<subdir>`) is problematic because it requires
`/run/lock` (or `/var/lock`) to already be created. They are created by the out-of-the-box `/usr/lib/tmpfiles.d/legacy.conf`, which means that in order to use them, we must either:

* Name this file lexicographically later than `legacy.conf`; or
* Duplicate the `/run/lock` (or "/var/lock") in this file
