### PR TITLE
CY-568: removed /var prefix

### DIFF
--- a/cfy_manager/components/rabbitmq/config/cloudify-rabbitmq
+++ b/cfy_manager/components/rabbitmq/config/cloudify-rabbitmq
@@ -1,5 +1,5 @@
 RABBITMQ_LOG_BASE="/var/log/cloudify/rabbitmq"
-RABBITMQ_PID_FILE="/var/run/rabbitmq/rabbitmq.pid"
+RABBITMQ_PID_FILE="/run/rabbitmq/rabbitmq.pid"
 RABBITMQ_CONFIG_FILE=/etc/cloudify/rabbitmq/rabbitmq
 RABBITMQ_NODENAME={{ rabbitmq.nodename }}
 RABBITMQ_ENABLED_PLUGINS_FILE=/etc/cloudify/rabbitmq/enabled_plugins


### PR DESCRIPTION
`/var/run` is deprecated, should use `/run` instead.