### PR TITLE
Support for calling add-networks from a cluster replica

### DIFF
--- a/cfy_manager/networks/scripts/add-networks-to-provider-context.py
+++ b/cfy_manager/networks/scripts/add-networks-to-provider-context.py
@@ -23,45 +23,12 @@ from manager_rest.constants import PROVIDER_CONTEXT_ID
 from manager_rest.storage import get_storage_manager, models
 
 try:
-    from cloudify_premium.ha.consul import get_consul_client, cluster_status
+    from cloudify_premium.ha.utils import node_status
+    from cloudify_premium.ha.agents import set_networks as set_node_networks
 except ImportError:
-    get_consul_client = None
-
-
-def _update_cluster_host_ip(networks, cluster_node_ip):
-    """
-    Add the new networks to the specified cluster node in the provider
-    context.
-    :param networks: a dict containing the new networks
-    :param cluster_node_ip: the default IP of the node to add networks to
-    """
-    with setup_flask_app().app_context():
-        sm = get_storage_manager()
-        ctx = sm.get(models.ProviderContext, PROVIDER_CONTEXT_ID)
-        old_networks = ctx.context['cloudify']['cloudify_agent']['networks']
-        # if we're the current master, update pctx
-        if cluster_node_ip == old_networks['default']:
-            old_networks.update(networks)
-
-        # find the node given by cluster_node_ip in the cluster list
-        # and update it
-        for node in ctx.context['cloudify']['cloudify_agent']['cluster']:
-            if node['default'] == cluster_node_ip:
-                node.update(networks)
-                break
-        else:
-            # should be caught by the validations before this
-            raise RuntimeError('Node not found')
-        flag_modified(ctx, 'context')
-        sm.update(ctx)
-
-    # set the networks in consul k/v options so that the remote node knows
-    # to re-generate the certs
-    options = cluster_status.cluster_options
-    if 'networks' not in options:
-        options['networks'] = {}
-    options['networks'][cluster_node_ip] = node
-    cluster_status.cluster_options = options
+    has_premium = False
+else:
+    has_premium = True
 
 
 def _update_provider_context(networks):
@@ -86,50 +53,6 @@ def _validate_networks(new_networks):
         _validate_duplicate_network(ctx, new_networks)
 
 
-def _validate_cluster(new_networks, cluster_node_ip):
-    with setup_flask_app().app_context():
-        sm = get_storage_manager()
-        ctx = sm.get(models.ProviderContext, PROVIDER_CONTEXT_ID)
-        _validate_premium()
-        _validate_cluster_node_ip(ctx, cluster_node_ip)
-        _validate_ca_key(ctx)
-
-
-def _validate_premium():
-    """Check that premium is installed.
-
-    Only relevant if cluster_node_ip was given.
-    """
-    if get_consul_client is None:
-        raise RuntimeError('Cloudify Premium is not available')
-
-
-def _validate_ca_key():
-    """Check that the cluster was created with the internal CA key.
-
-    If the internal CA key is not available, then recreating the certs
-    is not possible.
-    """
-    consul = get_consul_client()
-    ca = consul.kv.get('ca')
-    if 'internal_key' not in ca:
-        raise RuntimeError('Internal CA key is not available')
-
-
-def _validate_cluster_node_ip(ctx, cluster_node_ip):
-    """Check that cluster_node_ip does exist in the cluster
-
-    cluster_node_ip is the ip of the 'default' network of a cluster node.
-    """
-    try:
-        cluster = ctx.context['cloudify']['cloudify_agent']['cluster']
-    except KeyError:
-        raise RuntimeError('No cluster started')
-    if not any(node['default'] == cluster_node_ip for node in cluster):
-        raise RuntimeError('No cluster node with default IP {0} found'
-                           .format(cluster_node_ip))
-
-
 def _validate_duplicate_network(ctx, new_networks):
     """Check that all networks have unique names"""
     old_networks = ctx.context['cloudify']['cloudify_agent']['networks']
@@ -141,18 +64,15 @@ def _validate_duplicate_network(ctx, new_networks):
 
 
 if __name__ == '__main__':
-    if len(sys.argv) != 3:
+    if len(sys.argv) != 2:
         raise RuntimeError('`add-networks-to-provider-context.py` expects'
-                           ' exactly two arguments, it received {0} arguments'
+                           ' exactly one argument, it received {0} arguments'
                            .format(len(sys.argv) - 1))
     networks = sys.argv[1]
-    cluster_node_ip = sys.argv[2]
-
     networks = json.loads(networks)
 
-    _validate_networks(networks)
-    if cluster_node_ip:
-        _validate_cluster(networks, cluster_node_ip)
-        _update_cluster_host_ip(networks, cluster_node_ip)
+    if has_premium and node_status.get('initialized', False):
+        set_node_networks(networks)
     else:
+        _validate_networks(networks)
         _update_provider_context(networks)

--- a/cfy_manager/utils/certificates.py
+++ b/cfy_manager/utils/certificates.py
@@ -13,6 +13,7 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
+import os
 import argh
 import json
 import socket
@@ -283,6 +284,10 @@ def create_internal_certs(manager_ip=None,
     Recreate Cloudify Manager's internal certificates, based on the manager IP
     and a metadata file input
     """
+    if not os.path.exists(const.CA_CERT_PATH) or \
+            not os.path.exists(const.CA_KEY_PATH):
+        raise RuntimeError('Internal CA key and cert mus be available to '
+                           'generate internal certs')
     cert_metadata = load_cert_metadata(filename=metadata)
     internal_rest_host = manager_ip or cert_metadata['internal_rest_host']
 


### PR DESCRIPTION
No need for the complex passing info through the master to the replica:
simply create the certs right there on the replica (also added validation
that the CA key is available), and call the cloudify-premium API to add
the network to provider-context.