### PR TITLE
distributed tracing -  Add tracing settings for connection the tracing server

### DIFF
--- a/cfy_manager/components/restservice/config/cloudify-rest.conf
+++ b/cfy_manager/components/restservice/config/cloudify-rest.conf
@@ -26,5 +26,7 @@
     failed_logins_before_account_lock: {{ restservice.failed_logins_before_account_lock }},
     account_lock_period: {{ restservice.account_lock_period }},
     public_ip: '{{ manager.public_ip }}',
-    max_results: {{ restservice.max_results }}
+    max_results: {{ restservice.max_results }},
+    enable_tracing: {{ restservice.enable_tracing }},
+    tracing_endpoint_ip: '{{ restservice.tracing_endpoint_ip }}'
 }

--- a/config.yaml
+++ b/config.yaml
@@ -271,6 +271,12 @@ restservice:
   # file.
   extra_env: {}
 
+  # Flag that enables tracing
+  enable_tracing: false
+
+  # Tracing API reporting endpoint IP
+  tracing_endpoint_ip: localhost
+
 nginx:
   # Number of nginx worker processes to have.
   # Specify "auto" to use nginx's recommended configuration of one


### PR DESCRIPTION
- Adds a `enable_tracing` flag
- Adds a `tracing_endpoint_ip` IP field for the Jaeger API server IP