### PR TITLE
postgres_client: `groupadd` - use returncode to detect failures

### DIFF
--- a/cfy_manager/exceptions.py
+++ b/cfy_manager/exceptions.py
@@ -32,3 +32,9 @@ class ValidationError(BootstrapError):
 
 class InputError(BootstrapError):
     pass
+
+
+class ProcessExecutionError(BootstrapError):
+    def __init__(self, message, proc=None):
+        super(ProcessExecutionError, self).__init__(message)
+        self.proc = proc

--- a/cfy_manager/utils/common.py
+++ b/cfy_manager/utils/common.py
@@ -21,7 +21,7 @@ import subprocess
 
 from ..config import config
 from ..logger import get_logger
-from ..exceptions import BootstrapError
+from ..exceptions import ProcessExecutionError
 
 from . import subprocess_preexec
 
@@ -54,7 +54,7 @@ def run(command, retries=0, stdin=b'', ignore_failures=False,
         elif not ignore_failures:
             msg = 'Failed running command: {0} ({1}).'.format(
                 command_str, proc.aggr_stderr)
-            raise BootstrapError(msg)
+            raise ProcessExecutionError(msg)
     return proc
 
 


### PR DESCRIPTION
Instead of parsing the error message, simply look at the returncode.
`man groupadd` says:
```
    9
           group name not unique

```