### PR TITLE
CY-791: Management workers and REST service should connect to RMQ through localhost

### DIFF
--- a/cfy_manager/components/globals.py
+++ b/cfy_manager/components/globals.py
@@ -69,7 +69,6 @@ def _set_external_port_and_protocol():
 
 
 def _set_rabbitmq_config():
-    config[RABBITMQ][ENDPOINT_IP] = config[AGENT][BROKER_IP]
     config[RABBITMQ]['broker_cert_path'] = constants.CA_CERT_PATH
 
 

--- a/config.yaml
+++ b/config.yaml
@@ -104,6 +104,13 @@ rabbitmq:
   # Not used if an external endpoint is used.
   fd_limit: 102400
   nodename: cloudify-manager@localhost
+
+  # The hostname or IP address by which RabbitMQ is known to
+  # Cloudify Manager's components (REST service and management workers).
+  # This setting doesn't affect the hostname/IP by which agents access
+  # the manager.
+  endpoint_ip: localhost
+
   sources:
     erlang_rpm_source_url: erlang-21.0.2-1.el7.centos.x86_64.rpm
     socat_rpm_source_url: socat-1.7.3.2-2.el7.x86_64.rpm


### PR DESCRIPTION
I implemented this by adding `endpoint_ip` to `config.yaml`.
The default is `localhost`, which will cause `broker_config.json` and `cloudify-rest.conf` to render `localhost` as the AMQP address — as expected.
This also opens the door for microservices — user will be able to specify a different IP/host for `rabbitmq.endpoint_ip`, and this setting will make it to the relevant config files.