### PR TITLE
agents: enable heartbeats by default

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -96,7 +96,7 @@ agent:
   min_workers: 2
   max_workers: 5
   # AMQP heartbeat timeout. 0 means no heartbeats
-  heartbeat: 0
+  heartbeat: 30
 
 rabbitmq:
   # Sets the username/password to use for clients such as celery to connect to


### PR DESCRIPTION
Having them enabled is the backwards-compatible thing to do.
Users can still disable them here, or per-agent in the blueprint's
agent_config setting.

No heartbeats caused the auto-heal test to fail, because the new
agent (after heal) didn't receive the tasks, because rabbitmq thought
that the old agent was still connected (it wasn't, because the server
has been deleted, and the connection hasn't been closed cleanly)