### PR TITLE
Make logger names consistent

### DIFF
--- a/cfy_manager/components/__init__.py
+++ b/cfy_manager/components/__init__.py
@@ -13,22 +13,22 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
-from .amqp_postgres import AmqpPostgresComponent  # NOQA
-from .cli import CliComponent  # NOQA
-from .composer import ComposerComponent  # NOQA
-from .manager import ManagerComponent  # NOQA
-from .manager_ip_setter import ManagerIpSetterComponent  # NOQA
-from .mgmtworker import MgmtWorkerComponent  # NOQA
-from .nginx import NginxComponent  # NOQA
-from .postgresql_server import PostgresqlServerComponent  # NOQA
-from .postgresql_client import PostgresqlClientComponent # NOQA
-from .python import PythonComponent  # NOQA
-from .rabbitmq import RabbitMQComponent  # NOQA
-from .restservice import RestServiceComponent  # NOQA
-from .sanity import SanityComponent  # NOQA
-from .stage import StageComponent  # NOQA
-from .usage_collector import UsageCollectorComponent  # NOQA
-from .patch.patch import PatchComponent  # NOQA
+from .amqp_postgres import AmqpPostgres  # NOQA
+from .cli import Cli  # NOQA
+from .composer import Composer  # NOQA
+from .manager import Manager  # NOQA
+from .manager_ip_setter import ManagerIpSetter  # NOQA
+from .mgmtworker import MgmtWorker  # NOQA
+from .nginx import Nginx  # NOQA
+from .postgresql_server import PostgresqlServer  # NOQA
+from .postgresql_client import PostgresqlClient # NOQA
+from .python import Python  # NOQA
+from .rabbitmq import RabbitMQ  # NOQA
+from .restservice import RestService  # NOQA
+from .sanity import Sanity  # NOQA
+from .stage import Stage  # NOQA
+from .usage_collector import UsageCollector  # NOQA
+from .patch.patch import Patch  # NOQA
 
 from components_factory import ComponentsFactory  # NOQA
 from service_components import SERVICE_COMPONENTS  # NOQA

--- a/cfy_manager/components/amqp_postgres/__init__.py
+++ b/cfy_manager/components/amqp_postgres/__init__.py
@@ -13,4 +13,4 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
-from .amqp_postgres import AmqpPostgresComponent  # NOQA
+from .amqp_postgres import AmqpPostgres  # NOQA

--- a/cfy_manager/components/amqp_postgres/amqp_postgres.py
+++ b/cfy_manager/components/amqp_postgres/amqp_postgres.py
@@ -27,10 +27,10 @@ from ...constants import BASE_LOG_DIR
 logger = get_logger(AMQP_POSTGRES)
 
 
-class AmqpPostgresComponent(BaseComponent):
+class AmqpPostgres(BaseComponent):
 
     def __init__(self, skip_installation):
-        super(AmqpPostgresComponent, self).__init__(skip_installation)
+        super(AmqpPostgres, self).__init__(skip_installation)
 
     def _setup_log_dir(self):
         # Can't use AMQP_POSTGRES here because Jinja doesn't play nice

--- a/cfy_manager/components/cli/__init__.py
+++ b/cfy_manager/components/cli/__init__.py
@@ -13,4 +13,4 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
-from ..cli.cli import CliComponent  # NOQA
+from ..cli.cli import Cli  # NOQA

--- a/cfy_manager/components/cli/cli.py
+++ b/cfy_manager/components/cli/cli.py
@@ -32,10 +32,10 @@ from ...utils.install import yum_install, yum_remove
 logger = get_logger(CLI)
 
 
-class CliComponent(BaseComponent):
+class Cli(BaseComponent):
 
     def __init__(self, skip_installation):
-        super(CliComponent, self).__init__(skip_installation)
+        super(Cli, self).__init__(skip_installation)
 
     def _install(self):
         source_url = config[CLI][SOURCES]['cli_source_url']

--- a/cfy_manager/components/components_dependencies.py
+++ b/cfy_manager/components/components_dependencies.py
@@ -13,8 +13,6 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
-# region Dependencies with error messages
-
 DEPENDENCIES_ERROR_MESSAGES = {
     'sudo': 'necessary to run commands with root privileges',
     'openssl-1.0.2k': 'necessary for creating certificates',
@@ -30,29 +28,23 @@ DEPENDENCIES_ERROR_MESSAGES = {
     'openssh-server': 'required by the sanity check'
 }
 
-# endregion
-
-# region Components dependencies
-
 COMPONENTS_DEPENDENCIES = {
     'default': ['sudo', 'logrotate', 'yum', 'python-setuptools',
                 'python-backports', 'python-backports-ssl_match_hostname'],
-    'CliComponent': ['sed'],
-    'ComposerComponent': ['systemd-sysv', 'tar'],
-    'AmqpPostgresComponent': ['systemd-sysv'],
-    'ManagerComponent': [],
-    'ManagerIpSetterComponent': ['systemd-sysv'],
-    'MgmtWorkerComponent': ['systemd-sysv'],
-    'NginxComponent': ['systemd-sysv', 'openssl-1.0.2k'],
-    'PostgresqlServerComponent': ['systemd-sysv'],
-    'PostgresqlClientComponent': [],
-    'PythonComponent': [],
-    'RabbitMQComponent': ['initscripts', 'systemd-sysv'],
-    'RestServiceComponent': ['systemd-sysv'],
-    'SanityComponent': ['openssh-server'],
-    'StageComponent': ['systemd-sysv'],
-    'UsageCollectorComponent': [],
-    'PatchComponent': []
+    'Cli': ['sed'],
+    'Composer': ['systemd-sysv', 'tar'],
+    'AmqpPostgres': ['systemd-sysv'],
+    'Manager': [],
+    'ManagerIpSetter': ['systemd-sysv'],
+    'MgmtWorker': ['systemd-sysv'],
+    'Nginx': ['systemd-sysv', 'openssl-1.0.2k'],
+    'PostgresqlServer': ['systemd-sysv'],
+    'PostgresqlClient': [],
+    'Python': [],
+    'RabbitMQ': ['initscripts', 'systemd-sysv'],
+    'RestService': ['systemd-sysv'],
+    'Sanity': ['openssh-server'],
+    'Stage': ['systemd-sysv'],
+    'UsageCollector': [],
+    'Patch': []
 }
-
-# endregion

--- a/cfy_manager/components/components_factory.py
+++ b/cfy_manager/components/components_factory.py
@@ -15,22 +15,22 @@
 
 
 from . import (
-    AmqpPostgresComponent,
-    ManagerComponent,
-    ManagerIpSetterComponent,
-    NginxComponent,
-    PythonComponent,
-    PostgresqlServerComponent,
-    PostgresqlClientComponent,
-    RabbitMQComponent,
-    RestServiceComponent,
-    StageComponent,
-    ComposerComponent,
-    MgmtWorkerComponent,
-    CliComponent,
-    UsageCollectorComponent,
-    PatchComponent,
-    SanityComponent
+    AmqpPostgres,
+    Manager,
+    ManagerIpSetter,
+    Nginx,
+    Python,
+    PostgresqlServer,
+    PostgresqlClient,
+    RabbitMQ,
+    RestService,
+    Stage,
+    Composer,
+    MgmtWorker,
+    Cli,
+    UsageCollector,
+    Patch,
+    Sanity
 )
 
 
@@ -41,20 +41,20 @@ class ComponentsFactory:
     @staticmethod
     def create_component(component_name, skip_installation=False):
         return {
-            "manager": ManagerComponent(skip_installation),
-            "manager_ip_setter": ManagerIpSetterComponent(skip_installation),
-            "nginx": NginxComponent(skip_installation),
-            "python": PythonComponent(skip_installation),
-            "postgresql_server": PostgresqlServerComponent(skip_installation),
-            "postgresql_client": PostgresqlClientComponent(skip_installation),
-            "rabbitmq": RabbitMQComponent(skip_installation),
-            "restservice": RestServiceComponent(skip_installation),
-            "amqp_postgres": AmqpPostgresComponent(skip_installation),
-            "stage": StageComponent(skip_installation),
-            "composer": ComposerComponent(skip_installation),
-            "mgmtworker": MgmtWorkerComponent(skip_installation),
-            "cli": CliComponent(skip_installation),
-            "usage_collector": UsageCollectorComponent(skip_installation),
-            "patch": PatchComponent(skip_installation),
-            "sanity": SanityComponent(skip_installation)
+            "manager": Manager(skip_installation),
+            "manager_ip_setter": ManagerIpSetter(skip_installation),
+            "nginx": Nginx(skip_installation),
+            "python": Python(skip_installation),
+            "postgresql_server": PostgresqlServer(skip_installation),
+            "postgresql_client": PostgresqlClient(skip_installation),
+            "rabbitmq": RabbitMQ(skip_installation),
+            "restservice": RestService(skip_installation),
+            "amqp_postgres": AmqpPostgres(skip_installation),
+            "stage": Stage(skip_installation),
+            "composer": Composer(skip_installation),
+            "mgmtworker": MgmtWorker(skip_installation),
+            "cli": Cli(skip_installation),
+            "usage_collector": UsageCollector(skip_installation),
+            "patch": Patch(skip_installation),
+            "sanity": Sanity(skip_installation)
         }[component_name]

--- a/cfy_manager/components/composer/__init__.py
+++ b/cfy_manager/components/composer/__init__.py
@@ -13,4 +13,4 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
-from ..composer.composer import ComposerComponent  # NOQA
+from ..composer.composer import Composer  # NOQA

--- a/cfy_manager/components/composer/composer.py
+++ b/cfy_manager/components/composer/composer.py
@@ -49,10 +49,10 @@ COMPOSER_GROUP = '{0}_group'.format(COMPOSER)
 COMPOSER_PORT = 3000
 
 
-class ComposerComponent(BaseComponent):
+class Composer(BaseComponent):
 
     def __init__(self, skip_installation):
-        super(ComposerComponent, self).__init__(skip_installation)
+        super(Composer, self).__init__(skip_installation)
 
     def _create_paths(self):
         common.mkdir(NODEJS_DIR)

--- a/cfy_manager/components/manager/__init__.py
+++ b/cfy_manager/components/manager/__init__.py
@@ -13,4 +13,4 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
-from ..manager.manager import ManagerComponent  # NOQA
+from ..manager.manager import Manager  # NOQA

--- a/cfy_manager/components/manager/manager.py
+++ b/cfy_manager/components/manager/manager.py
@@ -40,9 +40,9 @@ CONFIG_PATH = join(constants.COMPONENTS_DIR, MANAGER, CONFIG)
 logger = get_logger(MANAGER)
 
 
-class ManagerComponent(BaseComponent):
+class Manager(BaseComponent):
     def __init__(self, skip_installation):
-        super(ManagerComponent, self).__init__(skip_installation)
+        super(Manager, self).__init__(skip_installation)
 
     def _get_exec_tempdir(self):
         return os.environ.get(constants.CFY_EXEC_TEMPDIR_ENVVAR) or \

--- a/cfy_manager/components/manager_ip_setter/__init__.py
+++ b/cfy_manager/components/manager_ip_setter/__init__.py
@@ -13,4 +13,4 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
-from ..manager_ip_setter.manager_ip_setter import ManagerIpSetterComponent  # NOQA
+from ..manager_ip_setter.manager_ip_setter import ManagerIpSetter  # NOQA

--- a/cfy_manager/components/manager_ip_setter/manager_ip_setter.py
+++ b/cfy_manager/components/manager_ip_setter/manager_ip_setter.py
@@ -30,9 +30,9 @@ MANAGER_IP_SETTER_DIR = join('/opt/cloudify', MANAGER_IP_SETTER)
 logger = get_logger(MANAGER_IP_SETTER)
 
 
-class ManagerIpSetterComponent(BaseComponent):
+class ManagerIpSetter(BaseComponent):
     def __init__(self, skip_installation):
-        super(ManagerIpSetterComponent, self).__init__(skip_installation)
+        super(ManagerIpSetter, self).__init__(skip_installation)
 
     def _install(self):
         sources = config[MANAGER_IP_SETTER][SOURCES]

--- a/cfy_manager/components/mgmtworker/__init__.py
+++ b/cfy_manager/components/mgmtworker/__init__.py
@@ -13,4 +13,4 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
-from ..mgmtworker.mgmtworker import MgmtWorkerComponent  # NOQA
+from ..mgmtworker.mgmtworker import MgmtWorker  # NOQA

--- a/cfy_manager/components/mgmtworker/cluster/__init__.py
+++ b/cfy_manager/components/mgmtworker/cluster/__init__.py
@@ -13,4 +13,4 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
-from ..cluster.cluster import ClusterComponent  # NOQA
+from ..cluster.cluster import Cluster  # NOQA

--- a/cfy_manager/components/mgmtworker/cluster/cluster.py
+++ b/cfy_manager/components/mgmtworker/cluster/cluster.py
@@ -21,7 +21,7 @@ from ...base_component import BaseComponent
 from ....utils.systemd import systemd
 from ....constants import COMPONENTS_DIR, CA_CERT_PATH
 from ....utils.common import sudo
-from ...restservice.restservice import RestServiceComponent
+from ...restservice.restservice import RestService
 from ....logger import get_logger
 from ....exceptions import BootstrapError, NetworkError
 from ....config import config
@@ -60,7 +60,7 @@ logger = get_logger('cluster')
 SCRIPTS_PATH = join(COMPONENTS_DIR, MGMTWORKER, CLUSTER, SCRIPTS)
 
 
-class ClusterComponent(BaseComponent):
+class Cluster(BaseComponent):
     def _generic_cloudify_rest_request(self, host, port, path,
                                        method, data=None):
         url = 'http://{0}:{1}/api/{2}'.format(host, port, path)
@@ -124,7 +124,7 @@ class ClusterComponent(BaseComponent):
         wait_for_port(rest_port)
 
         if verify_rest_call:
-            rest_service_component = RestServiceComponent()
+            rest_service_component = RestService()
             rest_service_component._verify_restservice_alive()
 
     def _log_results(self, result):

--- a/cfy_manager/components/mgmtworker/mgmtworker.py
+++ b/cfy_manager/components/mgmtworker/mgmtworker.py
@@ -15,7 +15,7 @@
 
 from os.path import join, dirname
 
-from .cluster.cluster import ClusterComponent
+from .cluster.cluster import Cluster
 
 from ..components_constants import (
     SOURCES,
@@ -50,9 +50,9 @@ CONFIG_PATH = join(const.COMPONENTS_DIR, MGMTWORKER, CONFIG)
 logger = get_logger(MGMTWORKER)
 
 
-class MgmtWorkerComponent(BaseComponent):
+class MgmtWorker(BaseComponent):
     def __init__(self, skip_installation):
-        super(MgmtWorkerComponent, self).__init__(skip_installation)
+        super(MgmtWorker, self).__init__(skip_installation)
 
     def _install(self):
         source_url = config[MGMTWORKER][SOURCES]['mgmtworker_source_url']
@@ -67,7 +67,7 @@ class MgmtWorkerComponent(BaseComponent):
             logger.notice('premium will not be installed.')
         else:
             logger.notice('Installing Cloudify Premium...')
-            cluster = ClusterComponent(skip_installation=False)
+            cluster = Cluster(skip_installation=False)
             cluster.install()
 
     def _deploy_mgmtworker_config(self):
@@ -157,7 +157,7 @@ class MgmtWorkerComponent(BaseComponent):
     def _configure(self):
         try:
             self._enter_sanity_mode()
-            cluster = ClusterComponent(skip_installation=False)
+            cluster = Cluster(skip_installation=False)
             cluster.configure()
             self._deploy_mgmtworker_config()
             systemd.configure(MGMTWORKER)

--- a/cfy_manager/components/nginx/__init__.py
+++ b/cfy_manager/components/nginx/__init__.py
@@ -13,4 +13,4 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
-from ..nginx.nginx import NginxComponent  # NOQA
+from ..nginx.nginx import Nginx  # NOQA

--- a/cfy_manager/components/nginx/nginx.py
+++ b/cfy_manager/components/nginx/nginx.py
@@ -46,9 +46,9 @@ UNIT_OVERRIDE_PATH = '/etc/systemd/system/nginx.service.d'
 logger = get_logger(NGINX)
 
 
-class NginxComponent(BaseComponent):
+class Nginx(BaseComponent):
     def __init__(self, skip_installation):
-        super(NginxComponent, self).__init__(skip_installation)
+        super(Nginx, self).__init__(skip_installation)
 
     def _install(self):
         nginx_source_url = config[NGINX][SOURCES]['nginx_source_url']

--- a/cfy_manager/components/patch/patch.py
+++ b/cfy_manager/components/patch/patch.py
@@ -22,10 +22,9 @@ from ...utils.install import yum_install, yum_remove
 logger = get_logger('patch')
 
 
-class PatchComponent(BaseComponent):
-
+class Patch(BaseComponent):
     def __init__(self, skip_installation):
-        super(PatchComponent, self).__init__(skip_installation)
+        super(Patch, self).__init__(skip_installation)
 
     def remove(self):
         yum_remove('patch')

--- a/cfy_manager/components/postgresql_client/__init__.py
+++ b/cfy_manager/components/postgresql_client/__init__.py
@@ -13,4 +13,4 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
-from .postgresql_client import PostgresqlClientComponent  # NOQA
+from .postgresql_client import PostgresqlClient  # NOQA

--- a/cfy_manager/components/postgresql_client/postgresql_client.py
+++ b/cfy_manager/components/postgresql_client/postgresql_client.py
@@ -57,9 +57,9 @@ PG_PORT = 5432
 logger = get_logger(POSTGRESQL_CLIENT)
 
 
-class PostgresqlClientComponent(BaseComponent):
+class PostgresqlClient(BaseComponent):
     def __init__(self, skip_installation):
-        super(PostgresqlClientComponent, self).__init__(skip_installation)
+        super(PostgresqlClient, self).__init__(skip_installation)
 
     def _install(self):
         sources = config[POSTGRESQL_CLIENT][SOURCES]

--- a/cfy_manager/components/postgresql_server/__init__.py
+++ b/cfy_manager/components/postgresql_server/__init__.py
@@ -13,4 +13,4 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
-from .postgresql_server import PostgresqlServerComponent  # NOQA
+from .postgresql_server import PostgresqlServer  # NOQA

--- a/cfy_manager/components/postgresql_server/postgresql_server.py
+++ b/cfy_manager/components/postgresql_server/postgresql_server.py
@@ -66,9 +66,9 @@ PG_PORT = 5432
 logger = get_logger(POSTGRESQL_SERVER)
 
 
-class PostgresqlServerComponent(BaseComponent):
+class PostgresqlServer(BaseComponent):
     def __init__(self, skip_installation):
-        super(PostgresqlServerComponent, self).__init__(skip_installation)
+        super(PostgresqlServer, self).__init__(skip_installation)
 
     def _install(self):
         sources = config[POSTGRESQL_SERVER][SOURCES]
@@ -254,4 +254,4 @@ class PostgresqlServerComponent(BaseComponent):
         logger.notice('PostgreSQL Server successfully stopped')
 
     def validate_dependencies(self):
-        super(PostgresqlServerComponent, self).validate_dependencies()
+        super(PostgresqlServer, self).validate_dependencies()

--- a/cfy_manager/components/python/__init__.py
+++ b/cfy_manager/components/python/__init__.py
@@ -13,4 +13,4 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
-from ..python.python import PythonComponent  # NOQA
+from ..python.python import Python  # NOQA

--- a/cfy_manager/components/python/python.py
+++ b/cfy_manager/components/python/python.py
@@ -24,9 +24,9 @@ from ...utils.files import copy_notice, remove_notice
 logger = get_logger(PYTHON)
 
 
-class PythonComponent(BaseComponent):
+class Python(BaseComponent):
     def __init__(self, skip_installation):
-        super(PythonComponent, self).__init__(skip_installation)
+        super(Python, self).__init__(skip_installation)
 
     def _install(self):
         if config[PYTHON]['install_python_compilers']:

--- a/cfy_manager/components/rabbitmq/__init__.py
+++ b/cfy_manager/components/rabbitmq/__init__.py
@@ -13,4 +13,4 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
-from ..rabbitmq.rabbitmq import RabbitMQComponent  # NOQA
+from ..rabbitmq.rabbitmq import RabbitMQ  # NOQA

--- a/cfy_manager/components/rabbitmq/rabbitmq.py
+++ b/cfy_manager/components/rabbitmq/rabbitmq.py
@@ -49,11 +49,11 @@ RABBITMQ_CTL = 'rabbitmqctl'
 logger = get_logger(RABBITMQ)
 
 
-class RabbitMQComponent(BaseComponent):
+class RabbitMQ(BaseComponent):
     component_name = 'rabbitmq'
 
     def __init__(self, skip_installation):
-        super(RabbitMQComponent, self).__init__(skip_installation)
+        super(RabbitMQ, self).__init__(skip_installation)
 
     def _install(self):
         sources = config[RABBITMQ][SOURCES]

--- a/cfy_manager/components/restservice/__init__.py
+++ b/cfy_manager/components/restservice/__init__.py
@@ -13,4 +13,4 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
-from ..restservice.restservice import RestServiceComponent  # NOQA
+from ..restservice.restservice import RestService  # NOQA

--- a/cfy_manager/components/restservice/restservice.py
+++ b/cfy_manager/components/restservice/restservice.py
@@ -65,9 +65,9 @@ logger = get_logger(RESTSERVICE)
 CLOUDIFY_LICENSE_PUBLIC_KEY_PATH = join(HOME_DIR, 'license_key.pem.pub')
 
 
-class RestServiceComponent(BaseComponent):
+class RestService(BaseComponent):
     def __init__(self, skip_installation=False):
-        super(RestServiceComponent, self).__init__(skip_installation)
+        super(RestService, self).__init__(skip_installation)
 
     def _make_paths(self):
         # Used in the service templates

--- a/cfy_manager/components/sanity/__init__.py
+++ b/cfy_manager/components/sanity/__init__.py
@@ -13,4 +13,4 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
-from ..sanity.sanity import SanityComponent  # NOQA
+from ..sanity.sanity import Sanity  # NOQA

--- a/cfy_manager/components/sanity/sanity.py
+++ b/cfy_manager/components/sanity/sanity.py
@@ -36,9 +36,9 @@ AUTHORIZED_KEYS_PATH = expanduser('~/.ssh/authorized_keys')
 SANITY_WEB_SERVER_PORT = 12774
 
 
-class SanityComponent(BaseComponent):
+class Sanity(BaseComponent):
     def __init__(self, skip_installation):
-        super(SanityComponent, self).__init__(skip_installation)
+        super(Sanity, self).__init__(skip_installation)
         random_postfix = str(uuid.uuid4())
         self.blueprint_name = '{0}_blueprint_{1}'.format(SANITY,
                                                          random_postfix)

--- a/cfy_manager/components/stage/__init__.py
+++ b/cfy_manager/components/stage/__init__.py
@@ -13,4 +13,4 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
-from ..stage.stage import StageComponent  # NOQA
+from ..stage.stage import Stage  # NOQA

--- a/cfy_manager/components/stage/stage.py
+++ b/cfy_manager/components/stage/stage.py
@@ -59,9 +59,9 @@ STAGE_RESOURCES = join(BASE_RESOURCES_PATH, STAGE)
 NODE_EXECUTABLE_PATH = '/usr/bin/node'
 
 
-class StageComponent(BaseComponent):
+class Stage(BaseComponent):
     def __init__(self, skip_installation):
-        super(StageComponent, self).__init__(skip_installation)
+        super(Stage, self).__init__(skip_installation)
 
     def _create_paths(self):
         common.mkdir(NODEJS_DIR)

--- a/cfy_manager/components/usage_collector/__init__.py
+++ b/cfy_manager/components/usage_collector/__init__.py
@@ -13,4 +13,4 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
-from ..usage_collector.usage_collector import UsageCollectorComponent  # NOQA
+from ..usage_collector.usage_collector import UsageCollector  # NOQA

--- a/cfy_manager/components/usage_collector/usage_collector.py
+++ b/cfy_manager/components/usage_collector/usage_collector.py
@@ -40,9 +40,9 @@ LOG_DIR = join(constants.BASE_LOG_DIR, USAGE_COLLECTOR)
 logger = get_logger(USAGE_COLLECTOR)
 
 
-class UsageCollectorComponent(BaseComponent):
+class UsageCollector(BaseComponent):
     def __init__(self, skip_installation):
-        super(UsageCollectorComponent, self).__init__(skip_installation)
+        super(UsageCollector, self).__init__(skip_installation)
 
     def install(self):
         logger.notice('Installing Usage Collector...')


### PR DESCRIPTION
This avoids having some logs appear as, e.g. RABBITMQ and others as,
e.g. RABBITMQCOMPONENT.

This also makes the install component logger names consistent with the
configure ones.