### PR TITLE
Support simple single-broker install for non-prod

### DIFF
--- a/cfy_manager/components/rabbitmq/rabbitmq.py
+++ b/cfy_manager/components/rabbitmq/rabbitmq.py
@@ -485,11 +485,9 @@ class RabbitMQ(BaseComponent):
         self._possibly_add_hosts_entries()
         systemd.configure(RABBITMQ,
                           user='rabbitmq', group='rabbitmq')
-        if (
-            self._installing_manager()
-            and not config[RABBITMQ]['cluster_members']
-        ):
-            # We must populate the brokers table for an all-in-one manager
+        if not config[RABBITMQ]['cluster_members']:
+            # We must populate the brokers table for an all-in-one manager,
+            # or a single external broker
             config[RABBITMQ]['cluster_members'] = {
                 'cloudify-broker': config['networks'],
             }


### PR DESCRIPTION
This makes the documentation in the config.yaml correct when it states that
cluster_members does not need filling in for single brokers.