### PR TITLE
CY-1043 Allow rabbitmq_tenant_credentials for user & operations

### DIFF
--- a/cfy_manager/components/restservice/config/authorization.conf
+++ b/cfy_manager/components/restservice/config/authorization.conf
@@ -482,6 +482,9 @@ permissions:
   tenant_rabbitmq_credentials:
     - sys_admin
     - manager
+    - user
+    - operations
+
   tenant_get:
     - sys_admin
     - manager


### PR DESCRIPTION
They have the ability to get those values already - by starting
an execution and examining the context (directly or creating an
agent).
This change is making that ability explicit.

With this and accompanying PRs, rabbitmq credentials no longer need
to be stored in cleartext in the operation context.