### PR TITLE
CY-1248 Don't require CA on a joining replica

### DIFF
--- a/.circleci/cluster/create_certs.sh
+++ b/.circleci/cluster/create_certs.sh
@@ -28,3 +28,11 @@ mv $MANAGER1_IP.key external_key_1.pem
 generate_test_cert $MANAGER2_IP
 mv $MANAGER2_IP.crt external_cert_2.pem
 mv $MANAGER2_IP.key external_key_2.pem
+
+generate_test_cert $MANAGER1_IP
+mv $MANAGER1_IP.crt manager_1_cert.pem
+mv $MANAGER1_IP.key manager_1_key.pem
+
+generate_test_cert $MANAGER2_IP
+mv $MANAGER2_IP.crt manager_2_cert.pem
+mv $MANAGER2_IP.key manager_2_key.pem

--- a/.circleci/cluster/manager1_config.yaml
+++ b/.circleci/cluster/manager1_config.yaml
@@ -24,7 +24,8 @@ ssl_inputs:
   postgresql_client_key_path: /etc/cloudify/postgres_client_key.pem
   postgresql_ca_cert_path: /etc/cloudify/ca.pem
   ca_cert_path: /etc/cloudify/ca.pem
-  ca_key_path: /etc/cloudify/ca_key.pem
+  internal_cert_path: /etc/cloudify/cert.pem
+  internal_key_path: /etc/cloudify/key.pem
   external_cert_path: /etc/cloudify/external_cert.pem
   external_key_path: /etc/cloudify/external_key.pem
   external_ca_cert_path: /etc/cloudify/ca.pem

--- a/.circleci/cluster/manager2_config.yaml
+++ b/.circleci/cluster/manager2_config.yaml
@@ -6,12 +6,6 @@ manager:
     ssl_enabled: true
     admin_password: admin
 
-rabbitmq:
-  ca_path: /etc/cloudify/ca.pem
-  cluster_members:
-    rabbit1:
-      default: QUEUE_IP
-
 postgresql_client:
   ssl_enabled: true
   postgres_password: postgres
@@ -22,8 +16,8 @@ ssl_inputs:
   postgresql_client_cert_path: /etc/cloudify/postgres_client_cert.pem
   postgresql_client_key_path: /etc/cloudify/postgres_client_key.pem
   postgresql_ca_cert_path: /etc/cloudify/ca.pem
-  ca_cert_path: /etc/cloudify/ca.pem
-  ca_key_path: /etc/cloudify/ca_key.pem
+  internal_cert_path: /etc/cloudify/cert.pem
+  internal_key_path: /etc/cloudify/key.pem
   external_cert_path: /etc/cloudify/external_cert.pem
   external_key_path: /etc/cloudify/external_key.pem
   external_ca_cert_path: /etc/cloudify/ca.pem

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,7 +189,10 @@ jobs:
 
             docker cp license.yaml ${MANAGER1_NAME}:/etc/cloudify/license.yaml
             docker cp ca.crt ${MANAGER1_NAME}:/etc/cloudify/ca.pem
-            docker cp ca.key ${MANAGER1_NAME}:/etc/cloudify/ca_key.pem
+            docker cp manager_1_cert.pem ${MANAGER1_NAME}:/etc/cloudify/cert.pem
+            docker cp manager_1_key.pem ${MANAGER1_NAME}:/etc/cloudify/key.pem
+
+
             docker cp external_cert_1.pem ${MANAGER1_NAME}:/etc/cloudify/external_cert.pem
             docker cp external_key_1.pem ${MANAGER1_NAME}:/etc/cloudify/external_key.pem
             docker cp db_client_1_key.pem ${MANAGER1_NAME}:/etc/cloudify/postgres_client_key.pem
@@ -205,9 +208,10 @@ jobs:
               -e "s/ACTIVE_MANAGER_IP/${MANAGER1_IP}/g" \
               .circleci/cluster/manager2_config.yaml > manager2_config.yaml
             docker cp manager2_config.yaml ${MANAGER2_NAME}:/etc/cloudify/config.yaml
-
             docker cp ca.crt ${MANAGER2_NAME}:/etc/cloudify/ca.pem
-            docker cp ca.key ${MANAGER2_NAME}:/etc/cloudify/ca_key.pem
+            docker cp manager_2_cert.pem ${MANAGER2_NAME}:/etc/cloudify/cert.pem
+            docker cp manager_2_key.pem ${MANAGER2_NAME}:/etc/cloudify/key.pem
+
             docker cp external_cert_2.pem ${MANAGER2_NAME}:/etc/cloudify/external_cert.pem
             docker cp external_key_2.pem ${MANAGER2_NAME}:/etc/cloudify/external_key.pem
             docker cp db_client_2_key.pem ${MANAGER2_NAME}:/etc/cloudify/postgres_client_key.pem

--- a/cfy_manager/components/nginx/nginx.py
+++ b/cfy_manager/components/nginx/nginx.py
@@ -99,7 +99,7 @@ class Nginx(BaseComponent):
         if config[SSL_INPUTS]['external_ca_key_password']:
             config[SSL_INPUTS]['external_ca_key_password'] = '<removed>'
 
-    def _handle_internal_cert(self, has_ca_key):
+    def _handle_internal_cert(self):
         """
         The user might provide the internal cert and the internal key, or
         neither. It is an error to only provide one of them. If the user did
@@ -107,7 +107,6 @@ class Nginx(BaseComponent):
         generate it if we have a CA key (either provided or generated).
         So it is an error to provide only the CA cert, and then not provide
         the internal cert+key.
-        :param has_ca_key: True if there's a CA key available
         """
         logger.info('Handling internal certificate...')
         cert_deployed, key_deployed = certificates.deploy_cert_and_key(
@@ -137,8 +136,7 @@ class Nginx(BaseComponent):
 
     def _handle_certs(self):
         if config[UNCONFIGURED_INSTALL] or config[CLEAN_DB]:
-            has_ca_key = certificates.handle_ca_cert()
-            self._handle_internal_cert(has_ca_key)
+            self._handle_internal_cert()
             self._handle_external_cert()
         else:
             logger.info('Skipping certificate handling. '

--- a/cfy_manager/components/restservice/db.py
+++ b/cfy_manager/components/restservice/db.py
@@ -189,8 +189,11 @@ def insert_manager(configs):
             'networks': config['networks'],
         }
     }
-    with open(constants.CA_CERT_PATH) as f:
-        args['manager']['ca_cert'] = f.read()
+    try:
+        with open(constants.CA_CERT_PATH) as f:
+            args['manager']['ca_cert'] = f.read()
+    except IOError:
+        args['manager']['ca_cert'] = None
     _run_script('create_tables_and_add_defaults.py', args, configs)
 
 

--- a/cfy_manager/components/restservice/restservice.py
+++ b/cfy_manager/components/restservice/restservice.py
@@ -50,7 +50,7 @@ from ...logger import (
     get_logger,
 )
 from ...exceptions import BootstrapError, NetworkError, InputError
-from ...utils import common
+from ...utils import certificates, common
 from ...utils.systemd import systemd
 from ...utils.install import yum_install, yum_remove
 from ...utils.network import get_auth_headers, wait_for_port
@@ -247,9 +247,11 @@ class RestService(BaseComponent):
             # configured
             logger.info('Manager not in DB, will join the cluster...')
             config[CLUSTER_JOIN] = True
+            certificates.handle_ca_cert(generate_if_missing=False)
             db.insert_manager(configs)
         elif result == constants.DB_NOT_INITIALIZED or config[CLEAN_DB]:
             logger.info('DB not initialized, creating DB...')
+            certificates.handle_ca_cert()
             db.prepare_db()
             db.populate_db(configs)
             db.insert_manager(configs)

--- a/cfy_manager/components/service_components.py
+++ b/cfy_manager/components/service_components.py
@@ -28,11 +28,11 @@ SERVICE_COMPONENTS = {
     ],
     "manager_service": [
         "manager",
+        "postgresql_client",
+        "restservice",
         "manager_ip_setter",
         "nginx",
         "python",
-        "postgresql_client",
-        "restservice",
         "amqp_postgres",
         "stage",
         "composer",

--- a/cfy_manager/utils/certificates.py
+++ b/cfy_manager/utils/certificates.py
@@ -35,7 +35,7 @@ from .. import constants as const
 logger = get_logger('Certificates')
 
 
-def handle_ca_cert():
+def handle_ca_cert(generate_if_missing=True):
     """
     The user might provide both the CA key and the CA cert, or just the
     CA cert, or nothing. It is an error to only provide the CA key.
@@ -57,7 +57,7 @@ def handle_ca_cert():
 
     if cert_deployed:
         logger.info('Deployed user provided CA cert')
-    else:
+    elif generate_if_missing:
         logger.info('Generating CA certificate...')
         generate_ca_cert()
         has_ca_key = True


### PR DESCRIPTION
When joining, the CA cert can be just downloaded from the db, no
need to provide it.
Also, when joining, all the queue details are also received from the db.