### PR TITLE
CY-1628 Don't fail uploading license on cluster

### DIFF
--- a/cfy_manager/components/restservice/restservice.py
+++ b/cfy_manager/components/restservice/restservice.py
@@ -449,8 +449,8 @@ class RestService(BaseComponent):
                         'after clustering configured')
         else:
             self._verify_restservice_alive()
+            self._upload_cloudify_license()
 
-        self._upload_cloudify_license()
         logger.notice('Rest Service successfully configured')
 
     def remove(self):

--- a/config.yaml
+++ b/config.yaml
@@ -41,6 +41,7 @@ manager:
     admin_password: ''
 
   # A path to a Cloudify license to be uploaded on the Manager during installation
+  # For clusters this must be supplied, and will only be used, on the first manager
   cloudify_license_path: ''
 
 manager-ip-setter:


### PR DESCRIPTION
The license is needed for the first manager anyway, and later ones have been failing if it is supplied.