### PR TITLE
CY-1625 Don't configure stage/composer db if not needed

### DIFF
--- a/cfy_manager/components/composer/composer.py
+++ b/cfy_manager/components/composer/composer.py
@@ -24,7 +24,8 @@ from ..components_constants import (
     SERVICE_GROUP,
     SSL_INPUTS,
     SSL_ENABLED,
-    SSL_CLIENT_VERIFICATION
+    SSL_CLIENT_VERIFICATION,
+    CLUSTER_JOIN
 )
 from ..base_component import BaseComponent
 from ..service_names import COMPOSER, POSTGRESQL_CLIENT, POSTGRESQL_SERVER
@@ -104,6 +105,9 @@ class Composer(BaseComponent):
         self._verify_composer_alive()
 
     def _run_db_migrate(self):
+        if config[CLUSTER_JOIN]:
+            logger.debug('Joining cluster - not creating the composer db')
+            return
         npm_path = join(NODEJS_DIR, 'bin', 'npm')
         common.run(
             [

--- a/cfy_manager/components/stage/stage.py
+++ b/cfy_manager/components/stage/stage.py
@@ -25,7 +25,8 @@ from ..components_constants import (
     SSL_INPUTS,
     SSL_ENABLED,
     SSL_CLIENT_VERIFICATION,
-    PREMIUM_EDITION
+    PREMIUM_EDITION,
+    CLUSTER_JOIN
 )
 from ..base_component import BaseComponent
 from ..service_names import (
@@ -159,6 +160,9 @@ class Stage(BaseComponent):
         )
 
     def _run_db_migrate(self):
+        if config[CLUSTER_JOIN]:
+            logger.debug('Joining cluster - not creating the stage db')
+            return
         backend_dir = join(HOME_DIR, 'backend')
         npm_path = join(NODEJS_DIR, 'bin', 'npm')
         common.run(


### PR DESCRIPTION
When joining a cluster, don't configure the db, it's already configured