### PR TITLE
CY-1796 cert validations: handle key password

### DIFF
--- a/.circleci/cluster/create_certs.sh
+++ b/.circleci/cluster/create_certs.sh
@@ -40,7 +40,3 @@ mv $MANAGER2_IP.key external_key_2.pem
 generate_test_cert $MANAGER1_IP
 mv $MANAGER1_IP.crt manager_1_cert.pem
 mv $MANAGER1_IP.key manager_1_key.pem
-
-generate_test_cert $MANAGER2_IP
-mv $MANAGER2_IP.crt manager_2_cert.pem
-mv $MANAGER2_IP.key manager_2_key.pem

--- a/.circleci/cluster/manager2_config.yaml
+++ b/.circleci/cluster/manager2_config.yaml
@@ -25,8 +25,9 @@ postgresql_client:
 ssl_inputs:
   postgresql_client_cert_path: /etc/cloudify/postgres_client_cert.pem
   postgresql_client_key_path: /etc/cloudify/postgres_client_key.pem
-  internal_cert_path: /etc/cloudify/cert.pem
-  internal_key_path: /etc/cloudify/key.pem
+  ca_cert_path: '/etc/cloudify/ca.pem'
+  ca_key_path: '/etc/cloudify/ca_key.pem'
+  ca_key_password: 'secret_ca_password'
   external_cert_path: /etc/cloudify/external_cert.pem
   external_key_path: /etc/cloudify/external_key.pem
   external_ca_cert_path: /etc/cloudify/ca.pem

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,8 +212,9 @@ jobs:
               .circleci/cluster/manager2_config.yaml > manager2_config.yaml
             docker cp manager2_config.yaml ${MANAGER2_NAME}:/etc/cloudify/config.yaml
             docker cp ca.crt ${MANAGER2_NAME}:/etc/cloudify/ca.pem
-            docker cp manager_2_cert.pem ${MANAGER2_NAME}:/etc/cloudify/cert.pem
-            docker cp manager_2_key.pem ${MANAGER2_NAME}:/etc/cloudify/key.pem
+            # encrypting the key to also test key passwords in config.yaml
+            openssl rsa -aes256 -passout pass:secret_ca_password -in ca.key  -out ca.encrypted.key
+            docker cp ca.encrypted.key ${MANAGER2_NAME}:/etc/cloudify/ca_key.pem
 
             docker cp external_cert_2.pem ${MANAGER2_NAME}:/etc/cloudify/external_cert.pem
             docker cp external_key_2.pem ${MANAGER2_NAME}:/etc/cloudify/external_key.pem

--- a/cfy_manager/components/validations.py
+++ b/cfy_manager/components/validations.py
@@ -326,7 +326,7 @@ def _check_cert_key_match(cert_filename, key_filename, password=None):
     key_modulus_command = ['openssl', 'rsa', '-noout', '-modulus',
                            '-in', key_filename]
     if password:
-        key_filename += ['-passin', 'pass:{0}'.format(password)]
+        key_modulus_command += ['-passin', 'pass:{0}'.format(password)]
     cert_modulus_command = ['openssl', 'x509', '-noout', '-modulus',
                             '-in', cert_filename]
     key_modulus = sudo(key_modulus_command).aggr_stdout.strip()

--- a/cfy_manager/components/validations.py
+++ b/cfy_manager/components/validations.py
@@ -290,7 +290,10 @@ def _check_ssl_file(filename, kind='Key', password=None):
     if kind == 'Key':
         check_command = ['openssl', 'rsa', '-in', filename, '-check', '-noout']
         if password:
-            check_command += ['-passin', 'pass:{0}'.format(password)]
+            check_command += [
+                '-passin',
+                u'pass:{0}'.format(password).encode('utf-8')
+            ]
     elif kind == 'Cert':
         check_command = ['openssl', 'x509', '-in', filename, '-noout']
     else:
@@ -326,7 +329,10 @@ def _check_cert_key_match(cert_filename, key_filename, password=None):
     key_modulus_command = ['openssl', 'rsa', '-noout', '-modulus',
                            '-in', key_filename]
     if password:
-        key_modulus_command += ['-passin', 'pass:{0}'.format(password)]
+        key_modulus_command += [
+            '-passin',
+            u'pass:{0}'.format(password).encode('utf-8')
+        ]
     cert_modulus_command = ['openssl', 'x509', '-noout', '-modulus',
                             '-in', cert_filename]
     key_modulus = sudo(key_modulus_command).aggr_stdout.strip()

--- a/cfy_manager/utils/certificates.py
+++ b/cfy_manager/utils/certificates.py
@@ -279,7 +279,8 @@ def _generate_ssl_certificate(ips,
             ]
             if sign_key_password:
                 x509_command += [
-                    '-passin', 'pass:{0}'.format(sign_key_password)
+                    '-passin',
+                    u'pass:{0}'.format(sign_key_password).encode('utf-8')
                 ]
         else:
             x509_command += [
@@ -342,7 +343,7 @@ def remove_key_encryption(src_key_path,
         'openssl', 'rsa',
         '-in', src_key_path,
         '-out', dst_key_path,
-        '-passin', 'pass:' + key_password
+        '-passin', u'pass:{0}'.format(key_password).encode('utf-8')
     ])
 
 

--- a/cfy_manager/utils/certificates.py
+++ b/cfy_manager/utils/certificates.py
@@ -484,7 +484,7 @@ def use_supplied_certificates(component_name,
 
     if key_pass:
         remove_key_encryption(
-            ca_destination, ca_destination, key_pass
+            key_destination, key_destination, key_pass
         )
 
     logger.info('Setting certificate ownership and permissions.')


### PR DESCRIPTION
Put the `-passin` in the command, not in the filename.

Also make the CI actually test this, and generating the internal cert at all.