### PR TITLE
CY-1856 Add default node_id values to managers and rabbit tables

### DIFF
--- a/cfy_manager/components/restservice/db.py
+++ b/cfy_manager/components/restservice/db.py
@@ -13,8 +13,9 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
-from os.path import join
 import time
+import uuid
+from os.path import join
 
 from .manager_config import make_manager_config
 from ..components_constants import (
@@ -154,6 +155,7 @@ def _create_args_dict():
                 'password': config[RABBITMQ]['password'],
                 'params': None,
                 'networks': broker,
+                'node_id': str(uuid.uuid4())
             }
             for name, broker in config[RABBITMQ]['cluster_members'].items()
         ],
@@ -216,6 +218,7 @@ def insert_manager(configs):
             'hostname': config[MANAGER][HOSTNAME],
             'private_ip': config['manager']['private_ip'],
             'networks': config['networks'],
+            'node_id': str(uuid.uuid4())
         }
     }
     try:

--- a/cfy_manager/components/restservice/scripts/create_tables_and_add_defaults.py
+++ b/cfy_manager/components/restservice/scripts/create_tables_and_add_defaults.py
@@ -14,13 +14,13 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
-import argparse
-import atexit
-import json
-import logging
 import os
-import subprocess
+import json
+import atexit
+import logging
 import tempfile
+import argparse
+import subprocess
 from datetime import datetime
 
 from flask_migrate import upgrade
@@ -123,7 +123,8 @@ def _insert_manager(config):
         version=version_data['version'],
         distribution=version_data['distribution'],
         distro_release=version_data['distro_release'],
-        _ca_cert_id=ca
+        _ca_cert_id=ca,
+        node_id=config['node_id']
     )
     sm.put(inst)
 


### PR DESCRIPTION
* Temp defaults, the uuid of the manager should be taken from a file
  that the manager reporter generates.

* The uuid of the rabbitmq_brokers should be taken from the
  config.yaml.