### PR TITLE
CY-1872 Add node_id for Rabbit and Postgres nodes in the config

### DIFF
--- a/.circleci/cluster/db_config.yaml
+++ b/.circleci/cluster/db_config.yaml
@@ -14,9 +14,12 @@ postgresql_server:
   postgres_password: 'somesecretvalue123!'
   cluster:
     nodes:
-      - DB1_IP
-      - DB2_IP
-      - DB3_IP
+      db_1:
+        ip: DB1_IP
+      db_2:
+        ip: DB2_IP
+      db_3:
+        ip: DB3_IP
     etcd:
       cluster_token: 'somesecretvalue123!'
       root_password: 'somesecretvalue123!'

--- a/.circleci/cluster/manager1_config.yaml
+++ b/.circleci/cluster/manager1_config.yaml
@@ -10,7 +10,9 @@ rabbitmq:
   ca_path: /etc/cloudify/ca.pem
   cluster_members:
     rabbit1:
-      default: QUEUE_IP
+      node_id: 'rabbit1_node_id'
+      networks:
+        default: QUEUE_IP
 
 postgresql_server:
   ssl_enabled: true
@@ -19,9 +21,15 @@ postgresql_server:
   postgres_password: 'somesecretvalue123!'
   cluster:
     nodes:
-      - DB1_IP
-      - DB2_IP
-      - DB3_IP
+      db_1:
+        ip: DB1_IP
+        node_id: 'db1_node_id'
+      db_2:
+        ip: DB2_IP
+        node_id: 'db2_node_id'
+      db_3:
+        ip: DB3_IP
+        node_id: 'db3_node_id'
 
 postgresql_client:
   ssl_enabled: true

--- a/.circleci/cluster/manager2_config.yaml
+++ b/.circleci/cluster/manager2_config.yaml
@@ -12,9 +12,15 @@ postgresql_server:
   postgres_password: 'somesecretvalue123!'
   cluster:
     nodes:
-      - DB1_IP
-      - DB2_IP
-      - DB3_IP
+      db_1:
+        ip: DB1_IP
+        node_id: 'db1_node_id'
+      db_2:
+        ip: DB2_IP
+        node_id: 'db2_node_id'
+      db_3:
+        ip: DB3_IP
+        node_id: 'db3_node_id'
 
 postgresql_client:
   ssl_enabled: true

--- a/cfy_manager/components/postgresql_server/config/etcd.conf
+++ b/cfy_manager/components/postgresql_server/config/etcd.conf
@@ -1,7 +1,7 @@
 ETCD_LISTEN_PEER_URLS='https://{{ manager.private_ip }}:2380'
 ETCD_LISTEN_CLIENT_URLS='https://localhost:2379,https://{{ manager.private_ip }}:2379'
 ETCD_INITIAL_ADVERTISE_PEER_URLS='https://{{ manager.private_ip }}:2380'
-ETCD_INITIAL_CLUSTER='{% for node in postgresql_server.cluster.nodes -%}etcd{{ node.replace('.', '_') }}=https://{{ node }}:2380,{% endfor %}'
+ETCD_INITIAL_CLUSTER='{% for node in postgresql_server.cluster.nodes.values() -%}etcd{{ node.ip.replace('.', '_') }}=https://{{ node.ip }}:2380,{% endfor %}'
 ETCD_ADVERTISE_CLIENT_URLS='https://{{ manager.private_ip }}:2379'
 ETCD_INITIAL_CLUSTER_TOKEN='{{ postgresql_server.cluster.etcd.cluster_token.replace("'", '"').replace('\\', '/') }}'
 ETCD_INITIAL_CLUSTER_STATE='new'

--- a/cfy_manager/components/postgresql_server/postgresql_server.py
+++ b/cfy_manager/components/postgresql_server/postgresql_server.py
@@ -315,7 +315,10 @@ class PostgresqlServer(BaseComponent):
         if local_only:
             addresses = [config[MANAGER][PRIVATE_IP]]
         else:
-            addresses = config[POSTGRESQL_SERVER]['cluster']['nodes']
+            addresses = [
+                node['ip'] for node in
+                config[POSTGRESQL_SERVER]['cluster']['nodes'].values()
+            ]
 
         endpoints = ','.join(
             'https://{addr}:2379'.format(addr=addr)
@@ -741,10 +744,10 @@ class PostgresqlServer(BaseComponent):
                 'password': pgsrv['cluster']['etcd']['patroni_password']
             },
         }
-        for node in pgsrv['cluster']['nodes']:
+        for node in pgsrv['cluster']['nodes'].values():
             self._add_node_to_pg_hba(
                 patroni_conf['bootstrap']['dcs']['postgresql']['pg_hba'],
-                node
+                node['ip']
             )
         common.sudo([
             'touch', patroni_config_path,

--- a/cfy_manager/components/restservice/config/haproxy.cfg
+++ b/cfy_manager/components/restservice/config/haproxy.cfg
@@ -18,7 +18,7 @@ listen postgres
     option httpchk
     http-check expect status 200
     default-server inter 3s fall 3 rise 2 on-marked-down shutdown-sessions
-{%- for node in postgresql_server.cluster.nodes %}
-    server postgresql_{{ node }}_5432 {{ node }}:5432 maxconn 100 check check-ssl port 8008 ca-file /etc/haproxy/ca.crt
+{%- for node in postgresql_server.cluster.nodes.values() %}
+    server postgresql_{{ node.ip }}_5432 {{ node.ip }}:5432 maxconn 100 check check-ssl port 8008 ca-file /etc/haproxy/ca.crt
 {%- endfor %}
 

--- a/cfy_manager/components/restservice/scripts/create_tables_and_add_defaults.py
+++ b/cfy_manager/components/restservice/scripts/create_tables_and_add_defaults.py
@@ -90,6 +90,12 @@ def _insert_rabbitmq_broker(brokers, ca_id):
         sm.put(inst)
 
 
+def _insert_db_nodes(db_nodes):
+    sm = get_storage_manager()
+    for node in db_nodes:
+        sm.put(models.DBNodes(**node))
+
+
 def _insert_manager(config):
     sm = get_storage_manager()
     ca_cert = config.get('ca_cert')
@@ -188,5 +194,8 @@ if __name__ == '__main__':
         _insert_manager(script_config['manager'])
     if script_config.get('provider_context'):
         _add_provider_context(script_config['provider_context'])
+    if script_config.get('db_nodes'):
+        _insert_db_nodes(script_config['db_nodes'])
+
     logger.info('Finished creating bootstrap admin, default tenant and '
                 'provider ctx')

--- a/cfy_manager/components/service_components.py
+++ b/cfy_manager/components/service_components.py
@@ -29,6 +29,7 @@ SERVICE_COMPONENTS = {
         "rabbitmq_status_reporter"
     ],
     "manager_service": [
+        "manager_status_reporter",
         "manager",
         "postgresql_client",
         "restservice",
@@ -40,7 +41,6 @@ SERVICE_COMPONENTS = {
         "composer",
         "mgmtworker",
         "cli",
-        "manager_status_reporter",
         "usage_collector",
         "patch",
         "sanity"

--- a/cfy_manager/components/status_reporter/status_reporter.py
+++ b/cfy_manager/components/status_reporter/status_reporter.py
@@ -21,6 +21,7 @@ from ..base_component import BaseComponent
 
 from ...logger import get_logger
 from ...components import sources
+from ...exceptions import InitializationError
 from ...utils.common import remove, move, chown
 from ...utils.files import write_to_tempfile
 from ...utils.systemd import systemd
@@ -28,10 +29,6 @@ from ...utils.install import yum_install, yum_remove
 from ...constants import STATUS_REPORTER, STATUS_REPORTER_CONFIGURATION_PATH
 
 logger = get_logger(STATUS_REPORTER)
-
-
-class InitializationError(Exception):
-    pass
 
 
 class StatusReporter(BaseComponent):

--- a/cfy_manager/exceptions.py
+++ b/cfy_manager/exceptions.py
@@ -56,3 +56,7 @@ class DBNodeListError(Exception):
 
 class DBManagementError(Exception):
     """Raised when there is an error managing DB cluster nodes."""
+
+
+class InitializationError(Exception):
+    pass

--- a/cfy_manager/utils/common.py
+++ b/cfy_manager/utils/common.py
@@ -28,7 +28,9 @@ from ..logger import get_logger
 from ..exceptions import ProcessExecutionError
 
 from cfy_manager.components.components_constants import SERVICES_TO_INSTALL
-from cfy_manager.components.service_components import DATABASE_SERVICE
+from cfy_manager.components.service_components import (QUEUE_SERVICE,
+                                                       MANAGER_SERVICE,
+                                                       DATABASE_SERVICE)
 from cfy_manager.components.service_names import (
     POSTGRESQL_CLIENT,
     POSTGRESQL_SERVER,
@@ -207,3 +209,11 @@ def get_haproxy_servers(logger):
         )
 
     return servers
+
+
+def is_all_in_one_manager():
+    return (
+        MANAGER_SERVICE in config[SERVICES_TO_INSTALL] and
+        DATABASE_SERVICE in config[SERVICES_TO_INSTALL] and
+        QUEUE_SERVICE in config[SERVICES_TO_INSTALL]
+    )

--- a/config.yaml
+++ b/config.yaml
@@ -92,16 +92,20 @@ rabbitmq:
 
   # A list of cluster members, including network-specific IPs.
   # The 'default' network IP must be set for each member.
-  # If installing a single external rabbit (not intended to be part of a cluster),
-  # or an all-in-one manager this section can be left blank.
+  # If installing an all-in-one manager this section can be left blank.
   # Example:
   # cluster_members:
   #   <hostname of rabbit node>:
-  #     default: <ip of rabbit node> (not needed if node name is resolvable via DNS)
-  #     <other network name>: <ip for this node on 'other network'>
+  #     node_id: <Cloudify's auto-generated id of the rabbit node> (only needed on
+  #              the first manager installed in a cluster)
+  #     networks:
+  #       default: <ip of rabbit node> (not needed if node name is resolvable via DNS)
+  #       <other network name>: <ip for this node on 'other network'>
   #     ...
   #   <name of second rabbit node>:
-  #     default: ...
+  #     node_id: ...
+  #     networks:
+  #       default: ...
   #     ...
   #   ...
   # All nodes must have a 'default' entry.
@@ -234,12 +238,19 @@ postgresql_server:
     # excessive resource usage.
     # If this is populated during a DB service install, the PostgreSQL cluster.
     # components will be installed.
-    # The nodes must be provided as IPs, e.g.
+    # The nodes must be provided with IPs, e.g.
     # nodes:
-    #   - 192.0.2.1
-    #   - 192.0.2.2
-    #   - 192.0.2.3
-    nodes: []
+    #   <hostname of postgres node>:
+    #     ip: <ip of postgres node>
+    #     node_id: <Cloudify's auto-generated id of the postgres node> (only needed on
+    #              the first manager installed in a cluster)
+    #   postgres_2:
+    #     ip: 192.0.2.2
+    #     node_id: c5c39913-b8d5-4130-99be-c29a2c970605
+    #   postgres_3:
+    #     ip: 192.0.2.3
+    #     node_id: 9e20bb07-0521-4b04-b675-d14a6995fa6d
+    nodes: {}
 
     # During DB cluster installation, all of the following cluster config
     # entries must be populated


### PR DESCRIPTION
* Change the format of db nodes in the config.yaml, it is a dict
  instead of a list and it includes the hostname, ip and node_id of a db node.

* Change the format of rabbit nodes in the config.yaml, add node_id and move
  the networks under 'networks' key.

* Insert the db nodes info to the DB.

* Set the hostname of the db and rabbit nodes in all-in-one manager to be the
  hostname of the manager.

* Take the manager node_id from the config of the reporter.

* Set the node_id of the db and rabbit nodes in all-in-one manager to be the
  node_id of the manager.

* If it is not all-in-one and there is no node_id configured in the rabbit nodes
  section, we assume it is an external rabbit (user-provided).