### PR TITLE
For community edition, node_id will be constant string

### DIFF
--- a/cfy_manager/components/mgmtworker/mgmtworker.py
+++ b/cfy_manager/components/mgmtworker/mgmtworker.py
@@ -37,7 +37,7 @@ from ...utils.files import (
     get_local_source_path
 )
 from ...utils.systemd import systemd
-from ...utils.install import yum_install, yum_remove, RpmPackageHandler
+from ...utils.install import yum_install, yum_remove, is_premium_installed
 from ...exceptions import FileError
 
 
@@ -82,16 +82,12 @@ class MgmtWorker(BaseComponent):
             common.chown('root', 'root', script_path)
             common.chmod('0500', script_path)
 
-    @staticmethod
-    def is_premium_installed():
-        return RpmPackageHandler.is_package_installed('cloudify-premium')
-
     def _deploy_mgmtworker_config(self):
         config[MGMTWORKER][HOME_DIR_KEY] = HOME_DIR
         config[MGMTWORKER][LOG_DIR_KEY] = LOG_DIR
         config[MGMTWORKER][SERVICE_USER] = const.CLOUDIFY_USER
         config[MGMTWORKER][SERVICE_GROUP] = const.CLOUDIFY_GROUP
-        if self.is_premium_installed():
+        if is_premium_installed():
             config[MGMTWORKER][CLUSTER_SERVICE_QUEUE] = \
                 'cluster_service_queue_{0}'.format(config[MANAGER][HOSTNAME])
 
@@ -146,7 +142,7 @@ class MgmtWorker(BaseComponent):
         systemd.verify_alive(MGMTWORKER)
 
     def _configure(self):
-        if self.is_premium_installed():
+        if is_premium_installed():
             cluster = Cluster(skip_installation=False)
             cluster.configure()
         self._deploy_mgmtworker_config()

--- a/cfy_manager/utils/install.py
+++ b/cfy_manager/utils/install.py
@@ -175,3 +175,7 @@ def pip_install(source, venv='', constraints_file=None):
 
     logger.info(log_message)
     sudo(cmdline)
+
+
+def is_premium_installed():
+    return RpmPackageHandler.is_package_installed('cloudify-premium')

--- a/cfy_manager/utils/node.py
+++ b/cfy_manager/utils/node.py
@@ -18,17 +18,21 @@ from os import path
 import yaml
 
 from .files import sudo_read
+from .install import is_premium_installed
 from ..exceptions import InitializationError
 from ..constants import STATUS_REPORTER_CONFIGURATION_PATH
 
 
 def get_node_id():
     if not path.exists(STATUS_REPORTER_CONFIGURATION_PATH):
-        raise InitializationError(
-            'Status reporter is not installed, path does not exist: {0}'
-            .format(STATUS_REPORTER_CONFIGURATION_PATH)
-        )
-
+        if is_premium_installed():
+            raise InitializationError(
+                'Status reporter is not installed, path does not exist: {0}'
+                .format(STATUS_REPORTER_CONFIGURATION_PATH)
+            )
+        else:
+            # Status reporter is not installed in community edition
+            return 'COMMUNITY'
     try:
         reporter_config = yaml.safe_load(
             sudo_read(STATUS_REPORTER_CONFIGURATION_PATH)


### PR DESCRIPTION
* Fix for the community build. The status reporter is not installed in
  community, so the config file does not exist and the node_id
  is not being generated.

* The node_id will be 'COMMUNITY' constant in this case.