### PR TITLE
Rabbitmq: put only IPs in /etc/hosts

### DIFF
--- a/cfy_manager/components/rabbitmq/rabbitmq.py
+++ b/cfy_manager/components/rabbitmq/rabbitmq.py
@@ -358,7 +358,15 @@ class RabbitMQ(BaseComponent):
                             node=node,
                         )
                     )
-                ip = socket.gethostbyname(ip)
+                try:
+                    ip = socket.gethostbyname(ip)
+                except socket.gaierror as e:
+                    raise ValidationError(
+                        'Cannot resolve: {addr} (rabbitmq node {node} default '
+                        'network address): {err}'.format(
+                            addr=ip, node=node, err=e
+                        )
+                    )
                 add_to_hosts.append('{ip} {name}'.format(
                     ip=ip,
                     name=node,

--- a/cfy_manager/components/rabbitmq/rabbitmq.py
+++ b/cfy_manager/components/rabbitmq/rabbitmq.py
@@ -15,6 +15,7 @@
 
 import json
 import time
+import socket
 from os.path import join
 
 import requests
@@ -357,6 +358,7 @@ class RabbitMQ(BaseComponent):
                             node=node,
                         )
                     )
+                ip = socket.gethostbyname(ip)
                 add_to_hosts.append('{ip} {name}'.format(
                     ip=ip,
                     name=node,


### PR DESCRIPTION
Resolve the default network address before putting it in hosts,
because hosts must have actual IPs