### PR TITLE
CY-2035 postgresql_server: format pg_hba addresses

### DIFF
--- a/cfy_manager/components/postgresql_server/postgresql_server.py
+++ b/cfy_manager/components/postgresql_server/postgresql_server.py
@@ -56,7 +56,7 @@ from ...config import config
 from ...logger import get_logger
 from ...utils.systemd import systemd
 from ...utils.install import yum_install, yum_remove
-from ...utils import common, files, db, node as cloudify_node
+from ...utils import common, files, db, node as cloudify_node, network
 
 POSTGRESQL_SCRIPTS_PATH = join(constants.COMPONENTS_DIR, POSTGRESQL_SERVER,
                                SCRIPTS)
@@ -500,8 +500,10 @@ class PostgresqlServer(BaseComponent):
                 # pg_hba in case this is being added to an existing cluster
                 patroni_conf = self._get_patroni_dcs_conf(local_only=False)
                 node_ip = config[MANAGER][PRIVATE_IP]
+                look_for = ' {address} '.format(
+                    address=self._format_pg_hba_address(node_ip))
                 if not any(
-                    ' {ip}/32 '.format(ip=node_ip) in entry
+                    look_for in entry
                     for entry in patroni_conf['postgresql']['pg_hba']
                 ):
                     self._add_node_to_pg_hba(
@@ -761,10 +763,31 @@ class PostgresqlServer(BaseComponent):
         with open(patroni_config_path, 'w') as f:
             f.write(yaml.dump(patroni_conf, default_flow_style=False))
 
+    def _format_pg_hba_address(self, address):
+        """Format the address for use in pg_hba
+
+        Postgresql expects the following in pg_hba:
+         - for ipv4 addresses: ip/32
+         - for ipv6 addresses: ip/128
+         - for names: no postfix
+        """
+        parsed = network.parse_ip(address)
+        if not parsed:  # name, not IP
+            return parsed
+        if parsed.version == 4:
+            return '{0}/32'.format(address)
+        elif parsed.version == 6:
+            return '{0}/128'.format(address)
+        else:
+            raise ValueError('Unexpected IP version in {0}: {1}'
+                             .format(address, parsed.version))
+
     def _add_node_to_pg_hba(self, pg_hba, node):
+        address = self._format_pg_hba_address(node)
         pg_hba[:0] = [
-            'hostssl all postgres {ip}/32 md5'.format(ip=node),
-            'hostssl replication replicator {ip}/32 md5'.format(ip=node)
+            'hostssl all postgres {address} md5'.format(address=address),
+            'hostssl replication replicator {address} md5'.format(
+                address=address)
         ]
 
     def _get_cluster_addresses(self):
@@ -1156,7 +1179,8 @@ class PostgresqlServer(BaseComponent):
                 'Updating pg_hba to remove {address}'.format(address=address)
             )
             patroni_config = self._get_patroni_dcs_conf()
-            exclusion_string = ' {addr}/32 '.format(addr=address)
+            exclusion_string = ' {address} '.format(
+                address=self._format_pg_hba_address(address))
             patroni_config['postgresql']['pg_hba'] = [
                 entry for entry in patroni_config['postgresql']['pg_hba']
                 if exclusion_string not in entry

--- a/cfy_manager/utils/certificates.py
+++ b/cfy_manager/utils/certificates.py
@@ -18,7 +18,8 @@ import argh
 import json
 from contextlib import contextmanager
 
-from .common import sudo, remove, chown, copy, network
+from . import network
+from .common import sudo, remove, chown, copy
 from ..components.components_constants import SSL_INPUTS
 from ..config import config
 from ..constants import SSL_CERTS_TARGET_DIR, CLOUDIFY_USER, CLOUDIFY_GROUP

--- a/cfy_manager/utils/certificates.py
+++ b/cfy_manager/utils/certificates.py
@@ -16,10 +16,9 @@
 import os
 import argh
 import json
-import socket
 from contextlib import contextmanager
 
-from .common import sudo, remove, chown, copy
+from .common import sudo, remove, chown, copy, network
 from ..components.components_constants import SSL_INPUTS
 from ..config import config
 from ..constants import SSL_CERTS_TARGET_DIR, CLOUDIFY_USER, CLOUDIFY_GROUP
@@ -103,20 +102,7 @@ def _format_ips(ips, cn=None):
     ]
     subject_altips = []
     for name in altnames:
-        ip_address = False
-        try:
-            socket.inet_pton(socket.AF_INET, name)
-            ip_address = True
-        except socket.error:
-            # Not IPv4
-            pass
-        try:
-            socket.inet_pton(socket.AF_INET6, name)
-            ip_address = True
-        except socket.error:
-            # Not IPv6
-            pass
-        if ip_address:
+        if network.parse_ip(name):
             subject_altips.append('IP:{name}'.format(name=name))
 
     cert_metadata = ','.join([

--- a/cfy_manager/utils/network.py
+++ b/cfy_manager/utils/network.py
@@ -20,6 +20,7 @@ import urllib2
 from time import sleep
 from tempfile import mkstemp
 from urlparse import urlparse
+from ipaddress import ip_address
 
 from ..exceptions import NetworkError
 from ..components.service_names import MANAGER
@@ -29,6 +30,18 @@ from ..config import config
 from ..logger import get_logger
 
 logger = get_logger('Network')
+
+
+def parse_ip(ip):
+    """Parse the string ip, and return an IPAddress or None"""
+    # ip should be unicode, coming from yaml, but in python 2
+    # it can unfortunately be bytes depending on the actual value
+    if isinstance(ip, bytes):
+        ip = ip.decode('utf-8')
+    try:
+        return ip_address(ip)
+    except ValueError:
+        return None
 
 
 def is_url(url):


### PR DESCRIPTION
pg_hba requires either a name, "ip/32", or "ipv6/128", but "name/32" is invalid