### PR TITLE
CY-2136 Postgres: add overrides for some basic settings

### DIFF
--- a/cfy_manager/components/postgresql_server/postgresql_server.py
+++ b/cfy_manager/components/postgresql_server/postgresql_server.py
@@ -194,6 +194,9 @@ class PostgresqlServer(BaseComponent):
                         ca_path=PG_CA_CERT_PATH,
                     )
                 )
+            for name, value in config[POSTGRESQL_SERVER]['config'].items():
+                conf_handle.write("{0} = '{1}'\n".format(name, value))
+
         return temp_pgconfig_path
 
     def _write_new_hba_file(self, lines, enable_remote_connections):

--- a/config.yaml
+++ b/config.yaml
@@ -228,6 +228,12 @@ postgresql_server:
   # THE PASSWORD WILL BE REMOVED FROM THE FILE AFTER THE INSTALLATION FINISHES
   postgres_password: ''
 
+  # postgresql.conf overrides
+  config:
+    shared_buffers: '1024MB'
+    effective_cache_size: '1024MB'
+    work_mem: '16MB'
+
   # PostgreSQL server's or cluster's public certificate, private key, and CA certificate
   # paths. All will be copied to the appropriate location and have permissions and
   # ownership set appropriately.


### PR DESCRIPTION
With some default settings that are mostly based on the minimum requirement
of a 4GB machine for a (AIO) manager