### PR TITLE
Status reporter: configure doesn't need to start it

### DIFF
--- a/.circleci/cluster/configure_status_reporter.sh
+++ b/.circleci/cluster/configure_status_reporter.sh
@@ -5,7 +5,7 @@ configure_reporter() {
   echo "Configuring status reporter for $1"
   docker cp ca.crt $1:/tmp/rest_ca.pem
   docker exec $1 cfy_manager status-reporter configure --managers-ip $2 --token $3 --ca-path /tmp/rest_ca.pem
-
+  docker exec $1 cfy_manager status-reporter start
 }
 
 for var in $1

--- a/cfy_manager/components/sanity/sanity.py
+++ b/cfy_manager/components/sanity/sanity.py
@@ -146,10 +146,7 @@ class Sanity(BaseComponent):
         self._remove_sanity_ssh(ssh_key_path)
         logger.notice('Sanity completed successfully')
 
-    def install(self):
-        pass
-
-    def configure(self):
+    def start(self):
         if config[SANITY]['skip_sanity'] or config[CLUSTER_JOIN]:
             logger.info('Skipping sanity check...')
             return

--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -710,6 +710,9 @@ def install(verbose=False,
             # install then we shouldn't configure
             if not component.skip_installation:
                 component.configure()
+        for component in components:
+            if not component.skip_installation:
+                component.start()
 
     if (MANAGER_SERVICE in config[SERVICES_TO_INSTALL] and
             QUEUE_SERVICE not in config[SERVICES_TO_INSTALL]):

--- a/cfy_manager/status_reporter/status_reporter.py
+++ b/cfy_manager/status_reporter/status_reporter.py
@@ -121,8 +121,6 @@ def configure(managers_ips=None, user_name='', token='', ca_path='',
                     json.dumps(passed_parameters, indent=1)))
     update_status_reporter_config(passed_parameters)
     _handle_ca_path(ca_path)
-    logger.info('Starting Status Reporter service...')
-    systemd.restart(STATUS_REPORTER)
     logger.notice('Status Reporter successfully configured')
 
 


### PR DESCRIPTION
When configuring the status reporter, no need to start it.
It doesn't seem there's any reason for this to happen, anyway

Starting it makes a dependency loop with the ipsetter as well
(ipsetter runs before status-reporter, so when in the ipsetter script we
attempt to do this, status-reporter can't start, because ipsetter didn't exit yet,
because it's waiting for the status-reporter to restart)