### PR TITLE
CY-2224 Add permissions for GET cluster-status

### DIFF
--- a/cfy_manager/components/restservice/config/authorization.conf
+++ b/cfy_manager/components/restservice/config/authorization.conf
@@ -129,6 +129,9 @@ permissions:
 
   cluster_status_get:
     - sys_admin
+    - manager
+    - user
+    - viewer
   manager_cluster_status_put:
     - manager_status_reporter
   db_cluster_status_put:


### PR DESCRIPTION
* By mistake only sys-admin had access to the GET cluster-status
  endpoint.

* Now also manager, user and viewer roles have access.