### PR TITLE
CY-2089 Make status-reporter work under supervisord

### DIFF
--- a/cfy_manager/components/status_reporter/status_reporter.py
+++ b/cfy_manager/components/status_reporter/status_reporter.py
@@ -62,7 +62,7 @@ class StatusReporter(BaseComponent):
         reporter_settings = {'reporter_type': self.reporter_type,
                              'extra_config_flags':
                                  self._build_extra_config_flags()}
-        service.configure(self.reporter_type,
+        service.configure(STATUS_REPORTER,
                           external_configure_params=reporter_settings,
                           src_dir=STATUS_REPORTER)
         logger.notice('Generating node id...')
@@ -81,7 +81,7 @@ class StatusReporter(BaseComponent):
     def remove(self):
         logger.notice('Removing status reporter {0}...'.format(
             self.reporter_type))
-        service.remove(self.reporter_type)
+        service.remove(STATUS_REPORTER)
         yum_remove('cloudify-status-reporter')
         logger.info('Removing status reporter directory...')
         remove_files([STATUS_REPORTER_PATH])

--- a/cfy_manager/components/status_reporter/supervisord.conf
+++ b/cfy_manager/components/status_reporter/supervisord.conf
@@ -1,3 +1,3 @@
-[program:cloudify-{{ reporter_type }}]
+[program:cloudify-status-reporter]
 autostart=false
 command=/opt/status-reporter/env/bin/cloudify_{{ reporter_type }} {{ extra_config_flags }}

--- a/cfy_manager/status_reporter/status_reporter.py
+++ b/cfy_manager/status_reporter/status_reporter.py
@@ -126,6 +126,12 @@ def configure(managers_ips=None, user_name='', token='', ca_path='',
                     json.dumps(passed_parameters, indent=1)))
     update_status_reporter_config(passed_parameters)
     _handle_ca_path(ca_path)
+    if no_restart:
+        logger.info('Status Reporter service\'s configuration change applied'
+                    ' successfully, a restart is required to activate it')
+        return
+    logger.info('Starting Status Reporter service...')
+    service.restart(STATUS_REPORTER)
     logger.notice('Status Reporter successfully configured')
 
 

--- a/cfy_manager/utils/service.py
+++ b/cfy_manager/utils/service.py
@@ -205,7 +205,7 @@ class Supervisord(object):
 
 
 def _get_backend():
-    if config.get('service_management') == 'supervisord':
+    if config.get('service_management', 'supervisord') == 'supervisord':
         return Supervisord()
     else:
         return SystemD()


### PR DESCRIPTION
- Unify the service name
- Default to using supervisord to allow things like
  `cfy_manager status_reporter start` to use it as well without
  having to parse the config