### PR TITLE
CY-2207 Configure PostgreSQL based on machine RAM

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -230,8 +230,13 @@ postgresql_server:
 
   # postgresql.conf overrides
   config:
-    shared_buffers: '1024MB'
-    effective_cache_size: '1024MB'
+    # Put here any compatible parameters that will override PostgreSQL defaults.
+    # We suggest and set as default values following:
+    #
+    #   * "shared_buffers": 25% of total RAM size,
+    #   * "effective_cache_size":
+    #       - 25% of total RAM size for all-in-one manager installation,
+    #       - 50% of total RAM size for cluster installation
     work_mem: '16MB'
 
   # PostgreSQL server's or cluster's public certificate, private key, and CA certificate

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         'netifaces==0.10.6',
         'ipaddress==1.0.19',
         'PyYAML==3.10',
+        'psutil==3.3.0',
         'requests==2.7.0',
         'retrying==1.3.3',
         'psycopg2==2.7.4'


### PR DESCRIPTION
Setting default PostgreSQL runtime parameters: `shared_buffers` and
`effective_cache_size` basing on machine RAM size:                                                   
                                                                                                       
* `shared_buffers`: 25% of total RAM size,                                                          
                                                                                                       
* `effective_cache_size`: 25% for all-in-one manager installation, 50% for cluster installation                                                                       
                                                                                                       
For all-in-one installation those values might be overwritten in `config.yaml` (`postgresql_server.config.shared_buffers` and `postgresql_server.config.effective_cache_size`).                                                    
                                                                                                       
Currently it is not possible to overwrite those for cluster installations.    