### PR TITLE
CY-2469 Drop PyYAML in favour of ruamel.yaml

### DIFF
--- a/cfy_manager/_compat.py
+++ b/cfy_manager/_compat.py
@@ -12,26 +12,32 @@
 #    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    * See the License for the specific language governing permissions and
 #    * limitations under the License.
-
 """Python 2 + 3 compatibility utils."""
 # flake8: noqa
 
 import sys
 PY2 = sys.version_info[0] == 2
 
-
 if PY2:
+    try:
+        from cStringIO import StringIO
+    except ImportError:
+        from StringIO import StringIO
+
     from urllib2 import HTTPError, URLError
     from urllib2 import Request, urlopen
     from urlparse import urlparse
 
 else:
+    from io import StringIO
+
     from urllib.error import HTTPError, URLError
     from urllib.request import Request, urlopen
     from urllib.parse import urlparse
 
 __all__ = [
     'PY2',
+    'StringIO',
     'HTTPError',
     'URLError',
     'Request',

--- a/cfy_manager/components/postgresql_server/postgresql_server.py
+++ b/cfy_manager/components/postgresql_server/postgresql_server.py
@@ -17,7 +17,6 @@ import os
 import re
 import time
 import json
-import yaml
 import psutil
 import socket
 from copy import copy
@@ -27,6 +26,8 @@ from os.path import join, isdir, islink
 
 import requests
 from retrying import retry
+from ruamel.yaml import YAML
+
 
 from cfy_manager.components import sources
 from cfy_manager.exceptions import (
@@ -835,8 +836,10 @@ class PostgresqlServer(BaseComponent):
             'touch', patroni_config_path,
         ])
         common.chown(getuser(), '', patroni_config_path)
+        yaml = YAML()
+        yaml.default_flow_style = False
         with open(patroni_config_path, 'w') as f:
-            f.write(yaml.dump(patroni_conf, default_flow_style=False))
+            yaml.dump(patroni_conf, f)
 
     def _format_pg_hba_address(self, address):
         """Format the address for use in pg_hba

--- a/cfy_manager/exceptions.py
+++ b/cfy_manager/exceptions.py
@@ -60,7 +60,3 @@ class DBManagementError(Exception):
 
 class InitializationError(Exception):
     pass
-
-
-class YAMLError(Exception):
-    """Raised when there is an YAML-related error."""

--- a/cfy_manager/exceptions.py
+++ b/cfy_manager/exceptions.py
@@ -60,3 +60,7 @@ class DBManagementError(Exception):
 
 class InitializationError(Exception):
     pass
+
+
+class YAMLError(Exception):
+    """Raised when there is an YAML-related error."""

--- a/cfy_manager/utils/files.py
+++ b/cfy_manager/utils/files.py
@@ -20,15 +20,16 @@ from glob import glob
 from tempfile import mkstemp
 from os.path import join, isabs
 
-import yaml
 from jinja2 import Environment, FileSystemLoader
+from ruamel.yaml import YAML
 
 from .network import is_url, curl_download
 from .common import move, sudo, copy, remove, chown
 
+from .._compat import StringIO
 from ..config import config
 from ..logger import get_logger
-from ..exceptions import FileError
+from ..exceptions import FileError, YAMLError
 from ..constants import CLOUDIFY_SOURCES_PATH, COMPONENTS_DIR
 
 logger = get_logger('Files')
@@ -198,10 +199,11 @@ def read_yaml_file(yaml_path):
     if is_file(yaml_path):
         try:
             file_content = sudo_read(yaml_path)
-            return yaml.safe_load(file_content)
-        except yaml.YAMLError as e:
-            raise yaml.YAMLError('Failed to load yaml file {0}, due to {1}'
-                                 ''.format(yaml_path, str(e)))
+            yaml = YAML(typ='safe', pure=True)
+            return yaml.load(file_content)
+        except Exception as e:
+            raise YAMLError('Failed to load yaml file {0}, due to {1}'
+                            ''.format(yaml_path, str(e)))
     return None
 
 
@@ -211,9 +213,11 @@ def update_yaml_file(yaml_path, user_owner, group_owner, updated_content):
                          'instead'.format(type(updated_content)))
     yaml_content = read_yaml_file(yaml_path) or {}
     yaml_content.update(**updated_content)
-    updated_file = yaml.safe_dump(yaml_content,
-                                  default_flow_style=False)
-    write_to_file(updated_file, yaml_path)
+    stream = StringIO()
+    yaml = YAML(typ='safe')
+    yaml.default_flow_style = False
+    yaml.dump(yaml_content, stream)
+    write_to_file(stream.getvalue(), yaml_path)
     chown(user_owner,
           group_owner,
           yaml_path)

--- a/cfy_manager/utils/files.py
+++ b/cfy_manager/utils/files.py
@@ -22,6 +22,7 @@ from os.path import join, isabs
 
 from jinja2 import Environment, FileSystemLoader
 from ruamel.yaml import YAML
+from ruamel.yaml.error import YAMLError
 
 from .network import is_url, curl_download
 from .common import move, sudo, copy, remove, chown
@@ -29,7 +30,7 @@ from .common import move, sudo, copy, remove, chown
 from .._compat import StringIO
 from ..config import config
 from ..logger import get_logger
-from ..exceptions import FileError, YAMLError
+from ..exceptions import FileError
 from ..constants import CLOUDIFY_SOURCES_PATH, COMPONENTS_DIR
 
 logger = get_logger('Files')
@@ -201,7 +202,7 @@ def read_yaml_file(yaml_path):
             file_content = sudo_read(yaml_path)
             yaml = YAML(typ='safe', pure=True)
             return yaml.load(file_content)
-        except Exception as e:
+        except YAMLError as e:
             raise YAMLError('Failed to load yaml file {0}, due to {1}'
                             ''.format(yaml_path, str(e)))
     return None

--- a/cfy_manager/utils/node.py
+++ b/cfy_manager/utils/node.py
@@ -14,6 +14,7 @@
 #  * limitations under the License.
 
 from ruamel.yaml import YAML
+from ruamel.yaml.error import YAMLError
 
 from .common import move, mkdir, chown
 from .install import is_premium_installed
@@ -48,7 +49,7 @@ def get_node_id():
         reporter_config = yaml.load(
             sudo_read(STATUS_REPORTER_CONFIGURATION_PATH)
         )
-    except Exception as e:
+    except YAMLError as e:
         raise InitializationError('Failed loading status reporter\'s '
                                   'configuration with the following: '
                                   '{0}'.format(e))

--- a/cfy_manager/utils/node.py
+++ b/cfy_manager/utils/node.py
@@ -13,7 +13,7 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
-import yaml
+from ruamel.yaml import YAML
 
 from .common import move, mkdir, chown
 from .install import is_premium_installed
@@ -43,10 +43,12 @@ def get_node_id():
             # Status reporter is not installed in community edition
             return 'COMMUNITY'
     try:
-        reporter_config = yaml.safe_load(
+        yaml = YAML(typ='safe')
+        yaml.default_flow_style = False
+        reporter_config = yaml.load(
             sudo_read(STATUS_REPORTER_CONFIGURATION_PATH)
         )
-    except yaml.YAMLError as e:
+    except Exception as e:
         raise InitializationError('Failed loading status reporter\'s '
                                   'configuration with the following: '
                                   '{0}'.format(e))

--- a/packaging/create_caravan.py
+++ b/packaging/create_caravan.py
@@ -2,12 +2,12 @@ from __future__ import print_function
 
 import argparse
 import json
-import yaml
 import tempfile
 import os
 import shutil
 import tarfile
 import requests
+from ruamel.yaml import YAML
 
 from cfy_manager._compat import urlopen
 
@@ -55,6 +55,8 @@ def _create_caravan(mappings, dest, tar_name):
 
         metadata[dest_wgn_path] = dest_yaml_path
 
+    yaml = YAML()
+    yaml.default_flow_style = False
     with open(os.path.join(tempdir, 'METADATA'), 'w+') as f:
         yaml.dump(metadata, f)
 

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ setup(
         'argh==0.26.2',
         'netifaces==0.10.6',
         'ipaddress==1.0.19',
-        'PyYAML==3.10',
         'psutil==3.3.0',
         'requests==2.7.0',
         'retrying==1.3.3',


### PR DESCRIPTION
Since ruamel.yaml is used all over the code, we have decided to get rid of PyYAML and stick with the single YAML loader/dumper package.