### PR TITLE
Reorder services: put mgmtworker before composer

### DIFF
--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -638,6 +638,7 @@ def _get_components(include_components=None):
             components.Cli(),
             components.AmqpPostgres(),
             components.MgmtWorker(),
+            components.Stage(),
         ]
         try:
             get_local_source_path(sources.composer)

--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -637,17 +637,17 @@ def _get_components(include_components=None):
             components.Nginx(),
             components.Cli(),
             components.AmqpPostgres(),
+            components.MgmtWorker(),
         ]
-        if is_package_available('cloudify-status-reporter'):
-            _components += [components.ManagerStatusReporter()]
         try:
             get_local_source_path(sources.composer)
         except FileError:
             logger.notice('Composer will not be installed: package not found')
         else:
             _components += [components.Composer()]
+        if is_package_available('cloudify-status-reporter'):
+            _components += [components.ManagerStatusReporter()]
         _components += [
-            components.MgmtWorker(),
             components.UsageCollector(),
         ]
         if not config[SANITY]['skip_sanity']:


### PR DESCRIPTION
"More important services first" means that you can still
get a mostly-working manager, even if one of the less-crucial
services fails installing
