### PR TITLE
CY-2841 Move the starter service to the python side

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -26,7 +26,6 @@ RUN yum install -y /tmp/cloudify-manager-install.rpm && rm /tmp/cloudify-manager
 COPY $config /etc/cloudify/config.yaml
 RUN cfy_manager install --only-install --verbose
 
-COPY starter.sh /opt/cloudify/starter.sh
 COPY starter.service /usr/lib/systemd/system/cloudify-starter.service
 RUN systemctl enable cloudify-starter.service
 

--- a/packaging/docker/starter.service
+++ b/packaging/docker/starter.service
@@ -6,4 +6,4 @@ WantedBy=multi-user.target
 
 [Service]
 Type=oneshot
-ExecStart=/opt/cloudify/starter.sh
+ExecStart=/usr/bin/cfy_manager image-starter

--- a/packaging/docker/starter.sh
+++ b/packaging/docker/starter.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -eux
-ip=$(/usr/sbin/ip a s | /usr/bin/grep -oE 'inet [^/]+' | /usr/bin/cut -d' ' -f2 | /usr/bin/grep -v '^127.' | /usr/bin/grep -v '^169.254.' | /usr/bin/head -n1)
-[ -e /tmp/config.yaml ] && cp /tmp/config.yaml /etc/cloudify/config.yaml || echo "Not copying config"
-cfy_manager configure --verbose --private-ip $ip --public-ip $ip
-cfy_manager start --verbose --private-ip $ip --public-ip $ip


### PR DESCRIPTION
Instead of the .sh that guesses the ip, it's nicer when it's
on the python side. Also, this will allow us to just use it
in the openstack image as well, instead of having to copy
the .sh over there as well.