### PR TITLE
Add a jenkins pipeline for building the main rpm

### DIFF
--- a/packaging/install_rpm.spec
+++ b/packaging/install_rpm.spec
@@ -17,7 +17,7 @@ URL:            https://github.com/cloudify-cosmo/cloudify-manager-install
 Vendor:         Cloudify Platform Ltd.
 Packager:       Cloudify Platform Ltd.
 
-BuildRequires:  python3 >= 3.6, python3-devel >= 3.6, createrepo
+BuildRequires:  python3 >= 3.6, python3-devel >= 3.6, createrepo, gcc
 Requires:       python3 >= 3.6
 
 %description

--- a/packaging/jenkins/build_rpm.groovy
+++ b/packaging/jenkins/build_rpm.groovy
@@ -1,0 +1,48 @@
+pipeline {
+    agent {
+        dockerfile {
+            dir 'packaging/jenkins/rpm_builder'
+            args '-u root -v /var/lib/jenkins/jobs/credentials.sh:/credentials.sh:ro'
+        }
+    }
+    parameters {
+        string(name: 'VERSION'. description: 'Cloudify version number, for use as a RPM Version (eg. 5.1.0)')
+        string(name: 'PRERELEASE', description: 'Cloudify milestone version number, for use as a RPM Release (eg. .dev1)')
+        string(name: 'BRANCH', defaultValue: 'master')
+        choice(name: 'EDITION', choices: 'premium\ncommunity')
+    }
+    stages {
+        stage('Download requirements'){
+            steps {
+                sh """
+                    ln -s "${WORKSPACE}" ~/rpmbuild/SOURCES
+                """
+                sh """
+                    source /credentials.sh > /dev/null 2>&1 &&
+                    mkdir rpms
+                    pushd 'rpms'
+                        ../packaging/fetch_requirements -b ${params.BRANCH} --edition ${params.EDITION}
+                    popd
+                """
+            }
+        }
+        stage('Build the manager RPM'){
+            steps {
+                sh """
+                    rpmbuild -D "CLOUDIFY_VERSION ${params.VERSION}" -D "CLOUDIFY_PACKAGE_RELEASE ${params.PRERELEASE}" -bb packaging/install_rpm.spec
+                """
+                sh """
+                    mv ~/rpmbuild/RPMS/x86_64/*.rpm "${WORKSPACE}"
+                """
+            }
+            post {
+                success {
+                    archiveArtifacts artifacts: '*.rpm', fingerprint: true
+                }
+                cleanup {
+                    cleanWs()
+                }
+            }
+        }
+    }
+}

--- a/packaging/jenkins/rpm_builder/Dockerfile
+++ b/packaging/jenkins/rpm_builder/Dockerfile
@@ -1,0 +1,5 @@
+FROM centos:7
+
+RUN yum install -y rpm-build git
+RUN yum install -y python3>=3.6 python3-devel>=3.6 createrepo gcc
+RUN mkdir /root/rpmbuild


### PR DESCRIPTION
We can use this in jenkins, instead of writing the job
configuration there. It's better to have scripts like this in
source control.

This is using a locally-built docker image for building the
rpm, instead of the rpmbuild/centos7 image, because:
1) the rpmbuild/centos7 image insists on running as a specific
  username/uid, and jenkins insists on running things as a different
  uid. So we `-u root` and run as root inside of the container instead
2) that image is not very official, and is not maintained by rh