### PR TITLE
docker images: implement `cfy_manager run-init`

### DIFF
--- a/.circleci/cluster/manager1_config.yaml
+++ b/.circleci/cluster/manager1_config.yaml
@@ -48,3 +48,5 @@ ssl_inputs:
 services_to_install:
 - manager_service
 - monitoring_service
+
+service_management: supervisord

--- a/.circleci/cluster/manager2_config.yaml
+++ b/.circleci/cluster/manager2_config.yaml
@@ -38,3 +38,5 @@ ssl_inputs:
 services_to_install:
 - manager_service
 - monitoring_service
+
+service_management: supervisord

--- a/cfy_manager/components/cli/cli.py
+++ b/cfy_manager/components/cli/cli.py
@@ -52,7 +52,7 @@ class Cli(BaseComponent):
         password = config[MANAGER][SECURITY]['admin_password']
 
         manager = config[MANAGER]['cli_local_profile_host_name']
-        use_cmd = ['cfy', 'profiles', 'use', manager,
+        use_cmd = ['profiles', 'use', manager,
                    '--skip-credentials-validation']
         if config['nginx']['port']:
             use_cmd += ['--rest-port', '{0}'.format(config['nginx']['port'])]
@@ -63,7 +63,7 @@ class Cli(BaseComponent):
         cert_path = self._deploy_external_cert()
         current_user = getuser()
         set_cmd = [
-            'cfy', 'profiles', 'set', '-u', username,
+            'profiles', 'set', '-u', username,
             '-p', password, '-t', 'default_tenant',
             '-c', cert_path, '--ssl', ssl_enabled
         ]
@@ -76,15 +76,14 @@ class Cli(BaseComponent):
         # to log file
         current_level = get_file_handlers_level()
         set_file_handlers_level(logging.ERROR)
-        common.run(use_cmd)
-        common.run(set_cmd)
+        common.cfy(*use_cmd)
+        common.cfy(*set_cmd)
         self._set_colors(is_root=False)
 
         if current_user != 'root':
             logger.info('Setting CLI for the root user...')
             for cmd in (use_cmd, set_cmd):
-                root_cmd = ['sudo', '-u', 'root'] + cmd
-                common.run(root_cmd)
+                common.cfy(*cmd, sudo=True)
             self._set_colors(is_root=True)
         set_file_handlers_level(current_level)
         logger.notice('Cloudify CLI successfully configured')
@@ -93,7 +92,7 @@ class Cli(BaseComponent):
         profile_name = config[MANAGER]['cli_local_profile_host_name']
 
         def _remove_profile_and_check(cli_cmd):
-            proc = common.run(cli_cmd, ignore_failures=True)
+            proc = common.cfy(*cli_cmd, ignore_failures=True)
             if proc.returncode == 0:
                 logger.notice('CLI profile removed')
             else:
@@ -103,7 +102,7 @@ class Cli(BaseComponent):
         try:
             logger.notice('Removing CLI profile...')
 
-            cmd = ['cfy', 'profiles', 'delete', profile_name]
+            cmd = ['profiles', 'delete', profile_name]
             _remove_profile_and_check(cmd)
 
             current_user = getuser()

--- a/cfy_manager/components/restservice/config/supervisord/haproxy.conf
+++ b/cfy_manager/components/restservice/config/supervisord/haproxy.conf
@@ -1,7 +1,7 @@
 [program:haproxy]
 user=haproxy
 group=haproxy
-command=/usr/sbin/haproxy-systemd-wrapper -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid
+command=/usr/sbin/haproxy-systemd-wrapper -f /etc/haproxy/haproxy.cfg -p /var/run/haproxy.pid
 environment=
     HOME="/var/lib/haproxy",
     USER="haproxy"

--- a/cfy_manager/components/sanity/sanity.py
+++ b/cfy_manager/components/sanity/sanity.py
@@ -90,20 +90,23 @@ class Sanity(BaseComponent):
         )
         common.run(['cfy', 'blueprints', 'upload', blueprint_path,
                     '-b', self.blueprint_name],
-                   stdout=sys.stdout)
+                   stdout=sys.stdout,
+                   env={'LC_ALL': 'en_US.UTF-8'})
 
     def _deploy_app(self):
         logger.info('Deploying sanity app...')
         common.run(['cfy', 'deployments', 'create', '-b', self.blueprint_name,
                     self.deployment_name,
                     '--skip-plugins-validation'],
-                   stdout=sys.stdout)
+                   stdout=sys.stdout,
+                   env={'LC_ALL': 'en_US.UTF-8'})
 
     def _install_sanity(self):
         logger.info('Installing sanity app...')
         common.run(['cfy', 'executions', 'start', 'install', '-d',
                     self.deployment_name],
-                   stdout=sys.stdout)
+                   stdout=sys.stdout,
+                   env={'LC_ALL': 'en_US.UTF-8'})
 
     @staticmethod
     def _clean_old_sanity():
@@ -121,12 +124,15 @@ class Sanity(BaseComponent):
         logger.info('Removing sanity...')
         common.run(['cfy', 'executions', 'start', 'uninstall', '-d',
                     self.deployment_name],
-                   stdout=sys.stdout)
+                   stdout=sys.stdout,
+                   env={'LC_ALL': 'en_US.UTF-8'})
         common.run(['cfy', 'deployments', 'delete', self.deployment_name],
-                   stdout=sys.stdout)
+                   stdout=sys.stdout,
+                   env={'LC_ALL': 'en_US.UTF-8'})
         time.sleep(3)
         common.run(['cfy', 'blueprints', 'delete', self.blueprint_name],
-                   stdout=sys.stdout)
+                   stdout=sys.stdout,
+                   env={'LC_ALL': 'en_US.UTF-8'})
 
     def run_sanity_check(self):
         logger.notice('Running Sanity...')

--- a/cfy_manager/components/sanity/sanity.py
+++ b/cfy_manager/components/sanity/sanity.py
@@ -18,22 +18,18 @@ import time
 import uuid
 import pkg_resources
 from contextlib import contextmanager
-from tempfile import mkdtemp
-from os.path import join, isfile, expanduser, dirname
 
 from ..components_constants import CLUSTER_JOIN
 from ..base_component import BaseComponent
 from ..service_names import SANITY
 from ...config import config
 from ...logger import get_logger
-from ...constants import CLOUDIFY_HOME_DIR, CLOUDIFY_USER, CLOUDIFY_GROUP
+from ...constants import CLOUDIFY_USER, CLOUDIFY_GROUP
 from ...utils import common
 from ...utils.files import write_to_file, remove_files
 
 
 logger = get_logger(SANITY)
-AUTHORIZED_KEYS_PATH = expanduser('~/.ssh/authorized_keys')
-SANITY_WEB_SERVER_PORT = 12774
 
 
 class Sanity(BaseComponent):
@@ -45,68 +41,28 @@ class Sanity(BaseComponent):
         self.deployment_name = '{0}_deployment_{1}'.format(SANITY,
                                                            random_postfix)
 
-    def _create_ssh_key(self):
-        logger.info('Creating SSH key for sanity...')
-        key_path = join(mkdtemp(), 'ssh_key')
-        common.run(['ssh-keygen', '-t', 'rsa', '-f', key_path, '-q', '-N', ''])
-        new_path = join(CLOUDIFY_HOME_DIR, 'ssh_key')
-        common.move(key_path, new_path)
-        common.chmod('600', new_path)
-        common.chown('cfyuser', 'cfyuser', new_path)
-        logger.debug('Created SSH key: {0}'.format(new_path))
-        self._add_ssh_key_to_authorized(key_path)
-        return new_path
-
-    @staticmethod
-    def _add_ssh_key_to_authorized(ssh_key_path):
-        public_ssh = '{0}.pub'.format(ssh_key_path)
-        if isfile(AUTHORIZED_KEYS_PATH):
-            logger.debug('Adding sanity SSH key to current authorized_keys...')
-            # Add a newline to the SSH file
-            common.run(['echo >> {0}'.format(AUTHORIZED_KEYS_PATH)],
-                       shell=True)
-            common.run(
-                ['cat {0} >> {1}'.format(public_ssh, AUTHORIZED_KEYS_PATH)],
-                shell=True
-            )
-            common.remove(public_ssh)
-        else:
-            logger.debug('Setting sanity SSH key as authorized_keys...')
-            common.move(public_ssh, AUTHORIZED_KEYS_PATH)
-        common.remove(dirname(ssh_key_path))
-
-    @staticmethod
-    def _remove_sanity_ssh(ssh_key_path):
-        # This removes the last line from the file
-        common.run(["sed -i '$ d' {0}".format(AUTHORIZED_KEYS_PATH)],
-                   shell=True)
-        common.remove(ssh_key_path)
-
     def _upload_blueprint(self):
         logger.info('Uploading sanity blueprint...')
         blueprint_path = pkg_resources.resource_filename(
             'cfy_manager',
             'components/sanity/blueprint/bp.yaml'
         )
-        common.run(['cfy', 'blueprints', 'upload', blueprint_path,
-                    '-b', self.blueprint_name],
-                   stdout=sys.stdout,
-                   env={'LC_ALL': 'en_US.UTF-8'})
+        common.cfy('blueprints', 'upload', blueprint_path,
+                   '-b', self.blueprint_name,
+                   stdout=sys.stdout)
 
     def _deploy_app(self):
         logger.info('Deploying sanity app...')
-        common.run(['cfy', 'deployments', 'create', '-b', self.blueprint_name,
-                    self.deployment_name,
-                    '--skip-plugins-validation'],
-                   stdout=sys.stdout,
-                   env={'LC_ALL': 'en_US.UTF-8'})
+        common.cfy('deployments', 'create', '-b', self.blueprint_name,
+                   self.deployment_name,
+                   '--skip-plugins-validation',
+                   stdout=sys.stdout)
 
     def _install_sanity(self):
         logger.info('Installing sanity app...')
-        common.run(['cfy', 'executions', 'start', 'install', '-d',
-                    self.deployment_name],
-                   stdout=sys.stdout,
-                   env={'LC_ALL': 'en_US.UTF-8'})
+        common.cfy('executions', 'start', 'install', '-d',
+                   self.deployment_name,
+                   stdout=sys.stdout)
 
     @staticmethod
     def _clean_old_sanity():
@@ -114,29 +70,23 @@ class Sanity(BaseComponent):
                      'installation if exists...')
         common.remove('/opt/mgmtworker/work/deployments/default_tenant/sanity')
 
-    def _run_sanity(self):
+    def _clean_sanity(self):
+        logger.info('Removing sanity...')
+        common.cfy('executions', 'start', 'uninstall', '-d',
+                   self.deployment_name,
+                   stdout=sys.stdout)
+        common.cfy('deployments', 'delete', self.deployment_name,
+                   stdout=sys.stdout)
+        time.sleep(3)
+        common.cfy('blueprints', 'delete', self.blueprint_name,
+                   stdout=sys.stdout)
+
+    def run_sanity_check(self):
+        logger.notice('Running Sanity...')
         self._clean_old_sanity()
         self._upload_blueprint()
         self._deploy_app()
         self._install_sanity()
-
-    def _clean_sanity(self):
-        logger.info('Removing sanity...')
-        common.run(['cfy', 'executions', 'start', 'uninstall', '-d',
-                    self.deployment_name],
-                   stdout=sys.stdout,
-                   env={'LC_ALL': 'en_US.UTF-8'})
-        common.run(['cfy', 'deployments', 'delete', self.deployment_name],
-                   stdout=sys.stdout,
-                   env={'LC_ALL': 'en_US.UTF-8'})
-        time.sleep(3)
-        common.run(['cfy', 'blueprints', 'delete', self.blueprint_name],
-                   stdout=sys.stdout,
-                   env={'LC_ALL': 'en_US.UTF-8'})
-
-    def run_sanity_check(self):
-        logger.notice('Running Sanity...')
-        self._run_sanity()
         self._clean_sanity()
         logger.notice('Sanity completed successfully')
 

--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -976,7 +976,7 @@ def _wait_supervisord_starter(timeout):
 
 
 @argh.decorators.named('wait-for-starter')
-def wait_for_starter(verbose=False, timeout=180):
+def wait_for_starter(verbose=False, timeout=300):
     _prepare_execution(verbose, config_write_required=False)
     config.load_config()
     if is_supervisord_service():

--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -859,13 +859,6 @@ def start(include_components,
     _validate_components_prepared('start')
     set_globals()
     logger.notice('Starting Cloudify Manager services...')
-    if is_supervisord_service():
-        # This is will be only relevant for running sshd service on container
-        sudo(
-            'supervisorctl -c /etc/supervisord.conf restart sshd',
-            ignore_failures=True
-        )
-
     for component in _get_components(include_components):
         component.start()
     logger.notice('Cloudify Manager services successfully started!')

--- a/cfy_manager/utils/common.py
+++ b/cfy_manager/utils/common.py
@@ -97,6 +97,14 @@ def sudo(command, *args, **kwargs):
     return run(command=command, *args, **kwargs)
 
 
+def cfy(*command, **kwargs):
+    # all `cfy` run calls have LC_ALL explicitly provided because
+    # click on py3.6 absolutely requires some locale to be set
+    env = {'LC_ALL': 'en_US.UTF-8'}
+    base = ['sudo', 'cfy'] if kwargs.pop('sudo', False) else ['cfy']
+    return run(base + list(command), env=env, **kwargs)
+
+
 def mkdir(folder, use_sudo=True):
     if os.path.isdir(folder):
         return

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -44,4 +44,4 @@ RUN chmod g+rx /etc/cloudify
 
 STOPSIGNAL SIGRTMIN+3
 VOLUME [ "/sys/fs/cgroup" ]
-CMD ["/bin/bash", "-c", "exec /sbin/init --log-target=journal 3>&1"]
+CMD ["/usr/bin/cfy_manager", "run-init"]

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -41,6 +41,8 @@ RUN systemctl enable cloudify-starter.service
 
 RUN usermod -aG cfyuser rabbitmq || true
 RUN chmod g+rx /etc/cloudify
+RUN mkdir -p /etc/supervisord.d
+COPY supervisord.conf /etc/supervisord.conf
 
 STOPSIGNAL SIGRTMIN+3
 VOLUME [ "/sys/fs/cgroup" ]

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -16,8 +16,7 @@ RUN groupadd -g $reporter_gid cfyreporter
 RUN yum install -y openssl-1.0.2k libselinux-utils \
     logrotate python-setuptools python-backports \
     python-backports-ssl_match_hostname which cronie \
-    systemd-sysv initscripts tcp_wrappers-libs sudo \
-    openssh-server
+    systemd-sysv initscripts tcp_wrappers-libs sudo
 
 EXPOSE 80 443 5672 53333
 COPY $config /tmp/config.yaml

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -42,6 +42,7 @@ RUN systemctl enable cloudify-starter.service
 RUN usermod -aG cfyuser rabbitmq || true
 RUN chmod g+rx /etc/cloudify
 RUN mkdir -p /etc/supervisord.d
+RUN chmod a+wx /var/run
 COPY supervisord.conf /etc/supervisord.conf
 
 STOPSIGNAL SIGRTMIN+3

--- a/packaging/docker/supervisord.conf
+++ b/packaging/docker/supervisord.conf
@@ -1,0 +1,26 @@
+[supervisord]
+logfile = /var/log/cloudify/supervisord.log
+
+[unix_http_server]
+file = /tmp/supervisor.sock
+chmod = 0770
+chown = cfyuser:cfyuser
+
+[supervisorctl]
+serverurl = unix:///tmp/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+
+[program:cloudify-starter]
+command=/usr/bin/cfy_manager image-starter
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/fd/2
+stderr_logfile_maxbytes=0
+startsecs=0
+autorestart=false
+
+[include]
+files=/etc/supervisord.d/*.conf

--- a/packaging/supervisord/Dockerfile
+++ b/packaging/supervisord/Dockerfile
@@ -30,4 +30,4 @@ RUN mkdir -p /etc/supervisord.d
 
 COPY sshd.conf /etc/supervisord.d/
 COPY supervisord.conf /etc/supervisord.conf
-CMD ["/usr/bin/supervisord", "-n", "-c", "/etc/supervisord.conf"]
+CMD ["/usr/bin/cfy_manager", "run-init"]


### PR DESCRIPTION
Implement a command that runs the configured service management system
(systemd or supervisord) so that we can just use this command and not have
two separate dockerfiles