### PR TITLE
Sanitycheck: use a locally-installed agent

### DIFF
--- a/cfy_manager/components/components_dependencies.py
+++ b/cfy_manager/components/components_dependencies.py
@@ -25,7 +25,6 @@ DEPENDENCIES_ERROR_MESSAGES = {
     'python-setuptools': 'required by python',
     'python-backports': 'required by python',
     'python-backports-ssl_match_hostname': 'required by python',
-    'openssh-server': 'required by the sanity check',
 }
 
 COMPONENTS_DEPENDENCIES = {
@@ -43,7 +42,7 @@ COMPONENTS_DEPENDENCIES = {
     'Python': [],
     'RabbitMQ': ['initscripts', 'systemd-sysv'],
     'RestService': ['systemd-sysv'],
-    'Sanity': ['openssh-server'],
+    'Sanity': [],
     'Stage': ['systemd-sysv'],
     'UsageCollector': [],
     'Patch': [],

--- a/cfy_manager/components/sanity/blueprint/bp.yaml
+++ b/cfy_manager/components/sanity/blueprint/bp.yaml
@@ -1,0 +1,25 @@
+tosca_definitions_version: cloudify_dsl_1_3
+
+imports:
+  - http://www.getcloudify.org/spec/cloudify/5.0.5/types.yaml
+
+plugins:
+  sanitycheck:
+    executor: central_deployment_agent
+    source: sanitycheck
+    install: true
+
+
+node_templates:
+  node1:
+    type: cloudify.nodes.Compute
+    properties:
+      agent_config:
+        install_method: plugin
+        process_management:
+          name: detach
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        create:
+          implementation: sanitycheck.sanitycheck.install_agent
+          executor: central_deployment_agent

--- a/cfy_manager/components/sanity/blueprint/plugins/sanitycheck/sanitycheck.py
+++ b/cfy_manager/components/sanity/blueprint/plugins/sanitycheck/sanitycheck.py
@@ -1,0 +1,12 @@
+import subprocess
+import tempfile
+
+from cloudify.decorators import operation
+
+
+@operation
+def install_agent(ctx, **_):
+    install_agent_script = ctx.agent.init_script({'user': 'cfyuser'})
+    with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
+        f.write(install_agent_script)
+    subprocess.check_call(['bash', f.name])

--- a/cfy_manager/components/sanity/blueprint/plugins/sanitycheck/setup.py
+++ b/cfy_manager/components/sanity/blueprint/plugins/sanitycheck/setup.py
@@ -1,0 +1,7 @@
+from setuptools import setup
+
+setup(
+    name='cloudify-sanitycheck-plugin',
+    version='1.0.0',
+    py_modules=['sanitycheck']
+)

--- a/cfy_manager/components/sources.py
+++ b/cfy_manager/components/sources.py
@@ -13,8 +13,6 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
-sanity = 'cloudify-hello-world-example-*.tar.gz'
-
 manager = [
     'cloudify-management-worker', 'cloudify-rest-service',
     'cloudify-cli', 'cloudify-manager-ip-setter', 'nginx',


### PR DESCRIPTION
No point in using ssh. We are testing ssh? Then we're not testing other methods.
What's the added value by testing ssh? None, really.
Tbh, we mostly only want to check that workflows are able to run, and that agents work.

So, instead of running the sanitycheck via ssh, run it locally. Makes it a lot faster,
and has WAY less requirements.