### PR TITLE
CY-3137 Add `host` labels to Prometheus scape_configs

### DIFF
--- a/cfy_manager/components/prometheus/config/prometheus.yml
+++ b/cfy_manager/components/prometheus/config/prometheus.yml
@@ -19,7 +19,6 @@ rule_files:
 # Here it's Prometheus itself.
 scrape_configs:
   - job_name: 'prometheus'
-    scheme: 'https'
     metrics_path: /monitoring/metrics
     static_configs:
       - targets: ['127.0.0.1:{{ prometheus.port }}']

--- a/cfy_manager/components/prometheus/config/prometheus.yml
+++ b/cfy_manager/components/prometheus/config/prometheus.yml
@@ -23,6 +23,8 @@ scrape_configs:
     metrics_path: /monitoring/metrics
     static_configs:
       - targets: ['127.0.0.1:{{ prometheus.port }}']
+        labels:
+          host: {{ manager.private_ip }}
 
   - job_name: 'node'
     static_configs:
@@ -110,8 +112,12 @@ scrape_configs:
   - job_name: 'postgresql'
     static_configs:
       - targets: ['localhost:{{ prometheus.postgres_exporter.metrics_port }}']
+        labels:
+          host: {{ manager.private_ip }}
 {% endif %}{% if 'queue_service' in services_to_install %}
   - job_name: 'rabbitmq'
     static_configs:
       - targets: ['localhost:{{ prometheus.rabbitmq_prometheus.metrics_port }}']
+        labels:
+          host: {{ manager.private_ip }}
 {% endif %}


### PR DESCRIPTION
The `host` labels are applied to `prometheus`, `postgresql` and `rabbitmq`
Prometheus jobs.