### PR TITLE
Refactor wait_for_starter

### DIFF
--- a/cfy_manager/logger.py
+++ b/cfy_manager/logger.py
@@ -117,6 +117,7 @@ def setup_console_logger(verbose=False):
     global logging_initialized
     if logging_initialized:
         return
+    _setup_logger()
     # Requests is fairly verbose at INFO level; make it verbose only when
     # requested
     logging.getLogger('requests').setLevel(
@@ -152,9 +153,6 @@ def _setup_file_logger(logger):
     fh.setLevel(logging.DEBUG)
     fh.setFormatter(logging.Formatter(FORMAT_MESSAGE))
     logger.addHandler(fh)
-
-
-_setup_logger()
 
 
 def get_logger(logger_name):

--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -975,7 +975,8 @@ def wait_for_starter(timeout=300):
     config.load_config()
 
     tail_log = subprocess.Popen([
-        '/usr/bin/tail', '-F', '/var/log/cloudify/manager/cfy_manager.log'
+        '/usr/bin/tail', '-F', '--max-unchanged-stats', '5', '-s', '0.5',
+        '/var/log/cloudify/manager/cfy_manager.log'
     ])
 
     is_started = _is_supervisord_service_finished \

--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -998,8 +998,7 @@ def _wait_supervisord_starter(timeout):
 
 
 @argh.decorators.named('wait-for-starter')
-def wait_for_starter(verbose=False, timeout=300):
-    _prepare_execution(verbose, config_write_required=False)
+def wait_for_starter(timeout=300):
     config.load_config()
     if is_supervisord_service():
         _wait_supervisord_starter(timeout)

--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -982,9 +982,7 @@ def wait_for_starter(timeout=300):
                 break
             time.sleep(0.5)
         else:
-            raise BootstrapError('Timed out')
-    except BootstrapError:
-        sys.exit(1)
+            raise BootstrapError('Timed out waiting for starter')
     finally:
         tail_log.terminate()
         tail_log.wait()

--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -984,6 +984,8 @@ def wait_for_starter(timeout=300):
         else:
             raise BootstrapError('Timed out waiting for starter')
     finally:
+        # allow a some time for tail to finish displaying logs
+        time.sleep(1)
         tail_log.terminate()
         tail_log.wait()
 

--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -926,7 +926,7 @@ def _is_unit_finished(unit_name='cloudify-starter.service'):
         name, _, value = line.strip().partition(b'=')
         if name == b'ExecMainExitTimestampMonotonic':
             rv = int(value) > 0
-        if name == b'ExecMainCode':
+        if name == b'ExecMainStatus':
             try:
                 value = int(value)
             except ValueError:


### PR DESCRIPTION
- make the systemd wait return 1 on errors
- show the useful log in the supervisord wait
- refactor the thing to have a common while loop
- carefully consider the logs to show the tracebacks nicely in wait-for-starter