### PR TITLE
fileserver: don't listen externally on ipv6

### DIFF
--- a/cfy_manager/components/nginx/config/https-file-server.cloudify
+++ b/cfy_manager/components/nginx/config/https-file-server.cloudify
@@ -2,7 +2,6 @@
 server {
     # server listening for internal requests
     listen              127.0.0.1:53229 ssl;
-    listen              [::]:53229 ssl;
     server_name         127.0.0.1;
 
     # force http redirect to https


### PR DESCRIPTION
This is a localhost-only component!

CY-769 was simply wrong about this component.