### PR TITLE
CY-3357 Add cfyuser to the rabbitmq group

### DIFF
--- a/packaging/install_rpm.spec
+++ b/packaging/install_rpm.spec
@@ -58,6 +58,8 @@ fi
 
 groupadd -fr cfyuser
 getent passwd cfyuser >/dev/null || useradd -r -g cfyuser -d /etc/cloudify -s /sbin/nologin cfyuser
+groupadd -fr rabbitmq
+usermod -aG rabbitmq cfyuser
 
 %post
 echo "


### PR DESCRIPTION
This is so that cfyuser can access the rabbitmq key, which is so that mgmtworker
can put it in a snapshot, in snap-create.