### PR TITLE
CF-3151 Remove postgres bin links

### DIFF
--- a/cfy_manager/components/postgresql_server/postgresql_server.py
+++ b/cfy_manager/components/postgresql_server/postgresql_server.py
@@ -1698,6 +1698,10 @@ class PostgresqlServer(BaseComponent):
         ], ignore_failure=True)
         files.remove_notice(POSTGRESQL_SERVER)
         service.remove(POSTGRES_SERVICE_NAME, append_prefix=False)
+        logger.info('Removing postgres bin links')
+        files.remove_files(
+            [os.path.join('/usr/sbin', pg_bin) for pg_bin in PG_BINS],
+            ignore_failure=True)
 
     def start(self):
         logger.notice('Starting PostgreSQL Server...')


### PR DESCRIPTION
During PostgreSQL server installation symlinks in /usr/sbin are generated
for PG_BINS.  Those were not removed during removal (`cfy_manager remove`).
This patch fixes that.