### PR TITLE
Fix error catch in validations

### DIFF
--- a/cfy_manager/components/validations.py
+++ b/cfy_manager/components/validations.py
@@ -16,7 +16,6 @@
 import os
 import sys
 import platform
-import subprocess
 import netifaces
 from getpass import getuser
 from collections import namedtuple
@@ -51,7 +50,7 @@ from ..logger import get_logger
 from ..constants import USER_CONFIG_PATH
 from ..exceptions import ValidationError
 
-from ..utils.common import run, sudo
+from ..utils.common import run, sudo, ProcessExecutionError
 from cfy_manager.utils.files import is_file
 
 logger = get_logger(VALIDATIONS)
@@ -315,7 +314,7 @@ def _check_signed_by(ca_filename, cert_filename):
     ]
     try:
         sudo(ca_check_command)
-    except subprocess.CalledProcessError:
+    except ProcessExecutionError:
         raise ValidationError(
             'Provided certificate {cert} was not signed by provided '
             'CA {ca}'.format(


### PR DESCRIPTION
`sudo` command throws `ProcessExecutionError` not `subprocess.CalledProcessError`. https://github.com/cloudify-cosmo/cloudify-manager-install/blob/76ecdd80b68414d6023a34c9a232aca486eccf07/cfy_manager/utils/common.py#L83. 

Only if it was Java...