### PR TITLE
Add agent uninstall in sanity-check

### DIFF
--- a/cfy_manager/components/sanity/blueprint/bp.yaml
+++ b/cfy_manager/components/sanity/blueprint/bp.yaml
@@ -23,3 +23,6 @@ node_templates:
         create:
           implementation: sanitycheck.sanitycheck.install_agent
           executor: central_deployment_agent
+        delete:
+          implementation: sanitycheck.sanitycheck.uninstall_agent
+          executor: central_deployment_agent

--- a/cfy_manager/components/sanity/blueprint/plugins/sanitycheck/sanitycheck.py
+++ b/cfy_manager/components/sanity/blueprint/plugins/sanitycheck/sanitycheck.py
@@ -1,5 +1,6 @@
 import subprocess
 import tempfile
+from os.path import expanduser
 
 from cloudify.decorators import operation
 
@@ -10,3 +11,18 @@ def install_agent(ctx, **_):
     with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
         f.write(install_agent_script)
     subprocess.check_call(['bash', f.name])
+
+
+@operation
+def uninstall_agent(ctx, **_):
+    daemon_delete_cmd = [
+        expanduser('~cfyuser/{0}/env/bin/cfy-agent'.format(ctx.instance.id)),
+        'daemons', 'delete', '--name', ctx.instance.id
+    ]
+    subprocess.check_call(daemon_delete_cmd,
+                          env={'CLOUDIFY_DAEMON_STORAGE_DIRECTORY':
+                               expanduser('~cfyuser/.cfy-agent/')})
+
+    runner_delete_cmd = ['rm', '-rf',
+                         expanduser('~cfyuser/{0}'.format(ctx.instance.id))]
+    subprocess.check_call(runner_delete_cmd)

--- a/cfy_manager/components/sanity/blueprint/plugins/sanitycheck/sanitycheck.py
+++ b/cfy_manager/components/sanity/blueprint/plugins/sanitycheck/sanitycheck.py
@@ -1,5 +1,6 @@
 import subprocess
 import tempfile
+import shutil
 from os.path import expanduser
 
 from cloudify.decorators import operation
@@ -23,6 +24,4 @@ def uninstall_agent(ctx, **_):
                           env={'CLOUDIFY_DAEMON_STORAGE_DIRECTORY':
                                expanduser('~cfyuser/.cfy-agent/')})
 
-    runner_delete_cmd = ['rm', '-rf',
-                         expanduser('~cfyuser/{0}'.format(ctx.instance.id))]
-    subprocess.check_call(runner_delete_cmd)
+    shutil.rmtree(expanduser('~cfyuser/{0}'.format(ctx.instance.id)))


### PR DESCRIPTION
A `delete` step was added in sanity-check blueprint.  It mimics
the `cloudify_agent.installer.LocalInstallerMixin.delete_agent` behaviour
by calling `cfy-agent daemons delete` on the specific node and then removing
the runner associated with the agent.