### PR TITLE
Remove service patroni-startup-check

### DIFF
--- a/cfy_manager/components/postgresql_server/postgresql_server.py
+++ b/cfy_manager/components/postgresql_server/postgresql_server.py
@@ -1755,6 +1755,7 @@ class PostgresqlServer(BaseComponent):
                 '/etc/patroni.conf',
                 '/etc/etcd',
             ])
+        service.remove('patroni_startup_check', append_prefix=False)
         logger.notice('Removing PostgreSQL...')
         files.remove_files([
             '/var/lib/pgsql/9.5/data',


### PR DESCRIPTION
In the case of running `cfy_manager remove` on a postgresql instance, the patroni_startup_check service is not removed. This PR fixes it.