### PR TITLE
CY-3537 Adding version flag to cfy_manager

### DIFF
--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -21,6 +21,7 @@ import re
 import sys
 import time
 import subprocess
+import pkg_resources
 from traceback import format_exception
 
 import argh
@@ -1174,6 +1175,11 @@ def _only_validate():
         component.validate_new_certs()
 
 
+@argh.named('version')
+def version():
+    return pkg_resources.require('cloudify-manager-install')[0].version
+
+
 def main():
     # Set the umask to 0022; restore it later.
     current_umask = os.umask(CFY_UMASK)
@@ -1197,6 +1203,7 @@ def main():
         image_starter,
         wait_for_starter,
         run_init,
+        version
     ])
 
     parser.add_commands([

--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -1177,7 +1177,8 @@ def _only_validate():
 
 @argh.named('version')
 def version():
-    print(pkg_resources.require('cloudify-manager-install')[0].version)
+    cfy_version = pkg_resources.require('cloudify-manager-install')[0].version
+    print('Cloudify {}'.format(cfy_version))
 
 
 def main():

--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -1177,8 +1177,9 @@ def _only_validate():
 
 @argh.named('version')
 def version():
+    setup_console_logger()
     cfy_version = pkg_resources.require('cloudify-manager-install')[0].version
-    print('Cloudify {}'.format(cfy_version))
+    logger.info('Cloudify {}'.format(cfy_version))
 
 
 def main():

--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -1177,7 +1177,7 @@ def _only_validate():
 
 @argh.named('version')
 def version():
-    return pkg_resources.require('cloudify-manager-install')[0].version
+    print(pkg_resources.require('cloudify-manager-install')[0].version)
 
 
 def main():


### PR DESCRIPTION
Adding `version` flag to `cfy_manager` commands in order to get the Cloudify version. Currently, the only option to get the version is by running `cfy --version` but this wouldn't work on PostgreSQL and RabbitMQ instances as they don't have the Cloudify CLI installed.