### PR TITLE
CY-3611 Mgmtworker: drop unused arguments

### DIFF
--- a/cfy_manager/components/mgmtworker/config/cloudify-mgmtworker
+++ b/cfy_manager/components/mgmtworker/config/cloudify-mgmtworker
@@ -14,7 +14,6 @@ MANAGER_FILE_SERVER_URL="{{ manager.file_server_url }}"
 MANAGER_FILE_SERVER_ROOT="{{ manager.file_server_root }}"
 MAX_WORKERS="{{ mgmtworker.max_workers }}"
 MIN_WORKERS="{{ mgmtworker.min_workers }}"
-CLUSTER_SERVICE_QUEUE="{{ mgmtworker.cluster_service_queue }}"
 {% for key, value in mgmtworker.extra_env.items() %}
 {{ key }}="{{ value }}"
 {% endfor %}

--- a/cfy_manager/components/mgmtworker/config/supervisord/cloudify-mgmtworker.conf
+++ b/cfy_manager/components/mgmtworker/config/supervisord/cloudify-mgmtworker.conf
@@ -1,7 +1,7 @@
 [program:cloudify-mgmtworker]
 user=cfyuser
 group=cfyuser
-command=/opt/mgmtworker/env/bin/python -m mgmtworker.worker --queue "cloudify.management" --max-workers {{ mgmtworker.max_workers }} --hooks-queue "cloudify-hooks" --cluster-service-queue {{ mgmtworker.cluster_service_queue | default('cluster-queue') }}
+command=/opt/mgmtworker/env/bin/python -m mgmtworker.worker --queue "cloudify.management" --max-workers {{ mgmtworker.max_workers }} --hooks-queue "cloudify-hooks"
 environment=
     HOME="/etc/cloudify",
     USER="cfyuser",
@@ -20,5 +20,4 @@ environment=
     MANAGER_FILE_SERVER_URL="{{ manager.file_server_url }}",
     MANAGER_FILE_SERVER_ROOT="{{ manager.file_server_root }}",
     MAX_WORKERS="{{ mgmtworker.max_workers }}",
-    MIN_WORKERS="{{ mgmtworker.min_workers }}",
-    CLUSTER_SERVICE_QUEUE="{{ mgmtworker.cluster_service_queue }}"{%- for key, value in mgmtworker.extra_env.items() -%},{{ key }}="{{ value }}"{%- endfor -%}{%- if postgresql_client.ssl_client_verification -%},PGSSLCERT={{ ssl_inputs.postgresql_client_cert_path }},PGSSLKEY={{ ssl_inputs.postgresql_client_key_path }}{%- endif -%}
+    MIN_WORKERS="{{ mgmtworker.min_workers }}"{%- for key, value in mgmtworker.extra_env.items() -%},{{ key }}="{{ value }}"{%- endfor -%}{%- if postgresql_client.ssl_client_verification -%},PGSSLCERT={{ ssl_inputs.postgresql_client_cert_path }},PGSSLKEY={{ ssl_inputs.postgresql_client_key_path }}{%- endif -%}

--- a/cfy_manager/components/mgmtworker/mgmtworker.py
+++ b/cfy_manager/components/mgmtworker/mgmtworker.py
@@ -21,10 +21,9 @@ from ..components_constants import (
     LOG_DIR_KEY,
     SERVICE_USER,
     SERVICE_GROUP,
-    HOSTNAME
 )
 from ..base_component import BaseComponent
-from ..service_names import MGMTWORKER, MANAGER
+from ..service_names import MGMTWORKER
 from ...config import config
 from ...logger import get_logger
 from ... import constants as const
@@ -34,12 +33,10 @@ from ...utils import (
     service
 )
 from ...utils.files import deploy
-from ...utils.install import is_premium_installed
 
 
 HOME_DIR = '/opt/mgmtworker'
 MGMTWORKER_VENV = join(HOME_DIR, 'env')
-CLUSTER_SERVICE_QUEUE = 'cluster_service_queue'
 LOG_DIR = join(const.BASE_LOG_DIR, MGMTWORKER)
 CONFIG_PATH = join(const.COMPONENTS_DIR, MGMTWORKER, CONFIG)
 HOOKS_CONFIG = join(HOME_DIR, 'config', 'hooks.conf')
@@ -74,10 +71,6 @@ class MgmtWorker(BaseComponent):
         config[MGMTWORKER][LOG_DIR_KEY] = LOG_DIR
         config[MGMTWORKER][SERVICE_USER] = const.CLOUDIFY_USER
         config[MGMTWORKER][SERVICE_GROUP] = const.CLOUDIFY_GROUP
-        if is_premium_installed():
-            config[MGMTWORKER][CLUSTER_SERVICE_QUEUE] = \
-                'cluster_service_queue_{0}'.format(config[MANAGER][HOSTNAME])
-
         self._deploy_hooks_config()
 
     def _deploy_admin_token(self):


### PR DESCRIPTION
This drops the arguments that stopped being used due to
cloudify-cosmo/cloudify-manager#2379