### PR TITLE
CY-3627 dbs list: _etcd_command for cluster-health

### DIFF
--- a/cfy_manager/components/postgresql_server/postgresql_server.py
+++ b/cfy_manager/components/postgresql_server/postgresql_server.py
@@ -1186,14 +1186,8 @@ class PostgresqlServer(BaseComponent):
         master = None
         replicas = []
         if DATABASE_SERVICE in config[SERVICES_TO_INSTALL]:
-            etcd_cluster_health = common.run(
-                [
-                    'etcdctl',
-                    '--endpoint', 'https://127.0.0.1:2379',
-                    '--ca-file', ETCD_CA_PATH,
-                    'cluster-health',
-                ],
-                ignore_failures=True
+            etcd_cluster_health = self._etcd_command(
+                ['cluster-health'], ignore_failures=True
             ).aggr_stdout
             if (
                 'cluster is unavailable' in etcd_cluster_health


### PR DESCRIPTION
Instead of calling etcdctl directly, use the utility method that
we already have.

That method will make sure to use the configured db IPs instead
of hardcoded 127.0.0.1.

This allows running `cfy_manager dbs list` if the etcd cert
(= the postgres cert) doesn't have 127.0.0.1 on it