### PR TITLE
CY-3673 Remove existing postgresql symlinks

### DIFF
--- a/cfy_manager/components/postgresql_server/postgresql_server.py
+++ b/cfy_manager/components/postgresql_server/postgresql_server.py
@@ -969,7 +969,7 @@ class PostgresqlServer(BaseComponent):
 
         logger.info('Creating postgres bin links for patroni')
         for pg_bin in PG_BINS:
-            common.sudo(['ln', '-s', os.path.join(PG_BIN_DIR, pg_bin),
+            common.sudo(['ln', '-s', '-f', os.path.join(PG_BIN_DIR, pg_bin),
                          '/usr/sbin'])
 
         logger.info('Starting patroni')


### PR DESCRIPTION
When installing Cloudify again on the same instance after a failed installation was removed, the installation process fails as it tries to create symlinks that already exist. This PR fixes it by deleting the symlinks if they already exist during installation.