### PR TITLE
RD-322 Update internal and external certs if exist

### DIFF
--- a/cfy_manager/components/nginx/nginx.py
+++ b/cfy_manager/components/nginx/nginx.py
@@ -221,7 +221,7 @@ class Nginx(BaseComponent):
     def _internal_certs_exist():
         if config[SSL_INPUTS]['internal_cert_path']:  # Certificate provided
             if exists(constants.INTERNAL_CERT_PATH):
-                return certificates.two_certs_identical(
+                return certificates.certs_identical(
                     config[SSL_INPUTS]['internal_cert_path'],
                     constants.INTERNAL_CERT_PATH)
             else:
@@ -254,7 +254,7 @@ class Nginx(BaseComponent):
     def _external_certs_exist():
         if config[SSL_INPUTS]['external_cert_path']:  # Certificate provided
             if exists(constants.EXTERNAL_CERT_PATH):
-                return certificates.two_certs_identical(
+                return certificates.certs_identical(
                     config[SSL_INPUTS]['external_cert_path'],
                     constants.EXTERNAL_CERT_PATH)
             else:

--- a/cfy_manager/components/nginx/nginx.py
+++ b/cfy_manager/components/nginx/nginx.py
@@ -217,11 +217,17 @@ class Nginx(BaseComponent):
             config[SSL_INPUTS]['external_ca_cert_path'] = \
                 constants.NEW_EXTERNAL_CA_CERT_FILE_PATH
 
-    def _internal_certs_exist(self):
-        return (
-            exists(constants.INTERNAL_CERT_PATH)
-            and exists(constants.INTERNAL_KEY_PATH)
-        )
+    @staticmethod
+    def _internal_certs_exist():
+        if config[SSL_INPUTS]['internal_cert_path']:  # Certificate provided
+            if exists(constants.INTERNAL_CERT_PATH):
+                return certificates.two_certs_identical(
+                    config[SSL_INPUTS]['internal_cert_path'],
+                    constants.INTERNAL_CERT_PATH)
+            else:
+                return False
+        else:
+            return exists(constants.INTERNAL_CERT_PATH)
 
     def _handle_external_cert(self, replacing_ca=False):
         cert_destinations = {
@@ -244,11 +250,17 @@ class Nginx(BaseComponent):
         else:
             self._generate_external_certs()
 
-    def _external_certs_exist(self):
-        return (
-            exists(constants.EXTERNAL_CERT_PATH)
-            and exists(constants.EXTERNAL_KEY_PATH)
-        )
+    @staticmethod
+    def _external_certs_exist():
+        if config[SSL_INPUTS]['external_cert_path']:  # Certificate provided
+            if exists(constants.EXTERNAL_CERT_PATH):
+                return certificates.two_certs_identical(
+                    config[SSL_INPUTS]['external_cert_path'],
+                    constants.EXTERNAL_CERT_PATH)
+            else:
+                return False
+        else:
+            return exists(constants.EXTERNAL_CERT_PATH)
 
     def _handle_certs(self):
         certs_handled = False
@@ -425,12 +437,6 @@ class Nginx(BaseComponent):
             LOG_DIR,
             UNIT_OVERRIDE_PATH,
             HTPASSWD_FILE,
-            constants.INTERNAL_CERT_PATH,
-            constants.INTERNAL_KEY_PATH,
-            constants.CA_CERT_PATH,
-            constants.EXTERNAL_CERT_PATH,
-            constants.EXTERNAL_KEY_PATH,
-            constants.EXTERNAL_CA_CERT_PATH
         ] + [resource.dst for resource in self._config_files()])
 
     def start(self):

--- a/cfy_manager/components/nginx/nginx.py
+++ b/cfy_manager/components/nginx/nginx.py
@@ -24,7 +24,6 @@ from ..components_constants import (
     PRIVATE_IP,
     PUBLIC_IP,
     SSL_INPUTS,
-    CLEAN_DB,
     HOSTNAME,
     SERVICES_TO_INSTALL
 )
@@ -217,12 +216,6 @@ class Nginx(BaseComponent):
             config[SSL_INPUTS]['external_ca_cert_path'] = \
                 constants.NEW_EXTERNAL_CA_CERT_FILE_PATH
 
-    def _internal_certs_exist(self):
-        return (
-            exists(constants.INTERNAL_CERT_PATH)
-            and exists(constants.INTERNAL_KEY_PATH)
-        )
-
     def _handle_external_cert(self, replacing_ca=False):
         cert_destinations = {
             'cert_destination': constants.EXTERNAL_CERT_PATH,
@@ -243,26 +236,6 @@ class Nginx(BaseComponent):
             logger.info('Deployed user provided external cert and key')
         else:
             self._generate_external_certs()
-
-    def _external_certs_exist(self):
-        return (
-            exists(constants.EXTERNAL_CERT_PATH)
-            and exists(constants.EXTERNAL_KEY_PATH)
-        )
-
-    def _handle_certs(self):
-        certs_handled = False
-        if config[CLEAN_DB] or not self._internal_certs_exist():
-            certs_handled = True
-            self._handle_internal_cert()
-        if config[CLEAN_DB] or not self._external_certs_exist():
-            certs_handled = True
-            self._handle_external_cert()
-
-        if not certs_handled:
-            logger.info('Skipping certificate handling. '
-                        'Pass the `--clean-db` flag in order to recreate '
-                        'all certificates')
 
     def _config_files(self):
         do_monitoring = MONITORING_SERVICE in config.get(SERVICES_TO_INSTALL)
@@ -430,7 +403,8 @@ class Nginx(BaseComponent):
     def start(self):
         logger.notice('Starting NGINX...')
         if MANAGER_SERVICE in config[SERVICES_TO_INSTALL]:
-            self._handle_certs()
+            self._handle_internal_cert()
+            self._handle_external_cert()
         if self.service_type == 'supervisord':
             service.configure(NGINX, append_prefix=False)
         service.restart(NGINX, append_prefix=False)

--- a/cfy_manager/utils/certificates.py
+++ b/cfy_manager/utils/certificates.py
@@ -90,8 +90,8 @@ def handle_ca_cert(logger, generate_if_missing=True):
 def _ca_cert_deployed():
     if config[SSL_INPUTS]['ca_cert_path']:  # Certificate provided
         if os.path.exists(const.CA_CERT_PATH):
-            return two_certs_identical(config[SSL_INPUTS]['ca_cert_path'],
-                                       const.CA_CERT_PATH)
+            return certs_identical(config[SSL_INPUTS]['ca_cert_path'],
+                                   const.CA_CERT_PATH)
         else:
             return False
     else:
@@ -594,12 +594,7 @@ def get_ca_filename(new_ca_location, default_ca_location):
             else default_ca_location)
 
 
-def _get_md5_hash(cert_path):
-    content = sudo(['openssl', 'x509', '-noout', '-modulus', '-in', cert_path])
-    md5_res = sudo(['openssl', 'md5'], stdin=content.aggr_stdout)
-    md5_hash = md5_res.aggr_stdout.split('(stdin)= ')[1]
-    return md5_hash
-
-
-def two_certs_identical(cert_a, cert_b):
-    return _get_md5_hash(cert_a) == _get_md5_hash(cert_b)
+def certs_identical(cert_a, cert_b):
+    content_a = sudo(['openssl', 'x509', '-noout', '-modulus', '-in', cert_a])
+    content_b = sudo(['openssl', 'x509', '-noout', '-modulus', '-in', cert_b])
+    return content_a.aggr_stdout == content_b.aggr_stdout

--- a/cfy_manager/utils/certificates.py
+++ b/cfy_manager/utils/certificates.py
@@ -41,7 +41,7 @@ def handle_ca_cert(logger, generate_if_missing=True):
     :return: True if there's a CA key available (either passed or
     generated)
     """
-    if os.path.exists(const.CA_CERT_PATH):
+    if _ca_cert_deployed():
         # CA certificate already deployed, no action required
         return os.path.exists(const.CA_KEY_PATH)
     logger.info('Handling CA certificate...')
@@ -85,6 +85,17 @@ def handle_ca_cert(logger, generate_if_missing=True):
         has_ca_key = True
 
     return has_ca_key
+
+
+def _ca_cert_deployed():
+    if config[SSL_INPUTS]['ca_cert_path']:  # Certificate provided
+        if os.path.exists(const.CA_CERT_PATH):
+            return two_certs_identical(config[SSL_INPUTS]['ca_cert_path'],
+                                       const.CA_CERT_PATH)
+        else:
+            return False
+    else:
+        return os.path.exists(const.CA_CERT_PATH)
 
 
 def _format_ips(ips, cn=None):
@@ -581,3 +592,14 @@ def get_cert_and_key_filenames(new_cert_location,
 def get_ca_filename(new_ca_location, default_ca_location):
     return (new_ca_location if os.path.exists(new_ca_location)
             else default_ca_location)
+
+
+def _get_md5_hash(cert_path):
+    content = sudo(['openssl', 'x509', '-noout', '-modulus', '-in', cert_path])
+    md5_res = sudo(['openssl', 'md5'], stdin=content.aggr_stdout)
+    md5_hash = md5_res.aggr_stdout.split('(stdin)= ')[1]
+    return md5_hash
+
+
+def two_certs_identical(cert_a, cert_b):
+    return _get_md5_hash(cert_a) == _get_md5_hash(cert_b)


### PR DESCRIPTION
Currently, if you would try to install Cloudify on a previously installed instance and provide new certificates, the internal and external certs won't be updated. This PR fixes it by implementing a new logic: 
Remark: "certificates" means internal-certificate or CA certificate

```
If the certificates were provided:
  If they already exist under /etc/cloudify/ssl:
    If the provided certificates and the certificates in /etc/cloudify/ssl are the same:
      Do nothing
    Otherwise:
      Replace them
  If they don't exist yet:
    Copy them to /etc/cloudify/ssl

If the certificates weren't provided:
  If the certificates exist:
    Do nothing 
  Otherwise:
    Generate them
```

This logic will identify whether or not the certificates need to be updated.