### PR TITLE
RD-78 Make scrape_interval configurable

### DIFF
--- a/cfy_manager/components/prometheus/config/alerts/manager.yml
+++ b/cfy_manager/components/prometheus/config/alerts/manager.yml
@@ -15,7 +15,7 @@ groups:
       # Alerting rules
       - alert: manager_down
         expr: probe_success == 0
-        for: 15s
+        for: {{ alert_for }}
         labels:
           severity: critical
         {% raw -%}
@@ -25,7 +25,7 @@ groups:
         {%- endraw %}
       - alert: blackbox_exporter_down
         expr: up{job=~"http_(200|401)"} == 0
-        for: 15s
+        for: {{ alert_for }}
         labels:
           severity: critical
         {% raw -%}
@@ -34,7 +34,7 @@ groups:
         {%- endraw %}
       - alert: manager_service_down
         expr: manager_service == 0
-        for: 15s
+        for: {{ alert_for }}
         labels:
           severity: warning
         {% raw -%}

--- a/cfy_manager/components/prometheus/config/alerts/missing.yml
+++ b/cfy_manager/components/prometheus/config/alerts/missing.yml
@@ -3,7 +3,7 @@ groups:
     rules:{% for host in hosts %}
       - alert: {{ name }}_missing
         expr: absent({{ name }}_healthy{host="{{ host }}"})
-        for: 15s
+        for: {{ alert_for }}
         labels:
           severity: critical
         annotations:
@@ -11,7 +11,7 @@ groups:
 
       - alert: prometheus_missing
         expr: absent(up{host="{{ host }}", job="prometheus"})
-        for: 15s
+        for: {{ alert_for }}
         labels:
           severity: critical
         annotations:

--- a/cfy_manager/components/prometheus/config/alerts/postgres.yml
+++ b/cfy_manager/components/prometheus/config/alerts/postgres.yml
@@ -15,7 +15,7 @@ groups:
       # Alerting rules
       - alert: postgres_down
         expr: pg_up == 0
-        for: 15s
+        for: {{ alert_for }}
         labels:
           severity: critical
         {% raw -%}
@@ -24,7 +24,7 @@ groups:
         {%- endraw %}
       - alert: postgres_exporter_down
         expr: up{job="postgresql"} == 0
-        for: 15s
+        for: {{ alert_for }}
         labels:
           severity: critical
         {% raw -%}
@@ -33,7 +33,7 @@ groups:
         {%- endraw %}
       - alert: postgres_service_down
         expr: postgres_service == 0
-        for: 15s
+        for: {{ alert_for }}
         labels:
           severity: warning
         {% raw -%}

--- a/cfy_manager/components/prometheus/config/alerts/rabbitmq.yml
+++ b/cfy_manager/components/prometheus/config/alerts/rabbitmq.yml
@@ -15,7 +15,7 @@ groups:
       # Alerting rules
       - alert: rabbitmq_down
         expr: up{job="rabbitmq"} == 0
-        for: 15s
+        for: {{ alert_for }}
         labels:
           severity: critical
         {% raw -%}
@@ -24,7 +24,7 @@ groups:
         {%- endraw %}
       - alert: rabbitmq_service_down
         expr: rabbitmq_service == 0
-        for: 15s
+        for: {{ alert_for }}
         labels:
           severity: warning
         {% raw -%}

--- a/cfy_manager/components/prometheus/config/prometheus.yml
+++ b/cfy_manager/components/prometheus/config/prometheus.yml
@@ -1,6 +1,6 @@
 global:
-  scrape_interval:     15s
-  evaluation_interval: 15s
+  scrape_interval: {{  prometheus.scrape_interval }}
+  evaluation_interval: {{  prometheus.scrape_interval }}
 
   external_labels:
     monitor: cloudify
@@ -58,7 +58,6 @@ scrape_configs:
         - '/etc/prometheus/targets/local_http_401_manager.yml'
 
   - job_name: 'federate_http_200'
-    scrape_interval: 15s
     honor_labels: true
     scheme: 'https'
     tls_config:
@@ -75,7 +74,6 @@ scrape_configs:
         - '/etc/prometheus/targets/other_managers.yml'
 
   - job_name: 'federate_http_401'
-    scrape_interval: 15s
     honor_labels: true
     scheme: 'https'
     tls_config:
@@ -92,7 +90,6 @@ scrape_configs:
         - '/etc/prometheus/targets/other_managers.yml'
 
   - job_name: 'federate_manager_prometheus'
-    scrape_interval: 15s
     honor_labels: true
     scheme: 'https'
     tls_config:
@@ -109,7 +106,6 @@ scrape_configs:
         - '/etc/prometheus/targets/other_managers.yml'
 
   - job_name: 'federate_manager_node'
-    scrape_interval: 15s
     honor_labels: true
     scheme: 'https'
     tls_config:
@@ -131,7 +127,6 @@ scrape_configs:
         - '/etc/prometheus/targets/local_rabbit.yml'
 
   - job_name: 'federate_rabbitmq'
-    scrape_interval: 15s
     honor_labels: true
     scheme: 'https'
     tls_config:
@@ -148,7 +143,6 @@ scrape_configs:
         - '/etc/prometheus/targets/other_rabbits.yml'
 
   - job_name: 'federate_rabbitmq_prometheus'
-    scrape_interval: 15s
     honor_labels: true
     scheme: 'https'
     tls_config:
@@ -165,7 +159,6 @@ scrape_configs:
         - '/etc/prometheus/targets/other_rabbits.yml'
 
   - job_name: 'federate_rabbitmq_node'
-    scrape_interval: 15s
     honor_labels: true
     scheme: 'https'
     tls_config:
@@ -187,7 +180,6 @@ scrape_configs:
         - '/etc/prometheus/targets/local_postgres.yml'
 
   - job_name: 'federate_postgresql'
-    scrape_interval: 15s
     honor_labels: true
     scheme: 'https'
     tls_config:
@@ -204,7 +196,6 @@ scrape_configs:
         - '/etc/prometheus/targets/other_postgres.yml'
 
   - job_name: 'federate_postgresql_prometheus'
-    scrape_interval: 15s
     honor_labels: true
     scheme: 'https'
     tls_config:
@@ -221,7 +212,6 @@ scrape_configs:
         - '/etc/prometheus/targets/other_postgres.yml'
 
   - job_name: 'federate_postgresql_node'
-    scrape_interval: 15s
     honor_labels: true
     scheme: 'https'
     tls_config:

--- a/config.yaml
+++ b/config.yaml
@@ -563,6 +563,8 @@ prometheus:
   credentials:
     username: 'monitoring_user'
     password: 'm0n1torify'
+  # How frequently should Prometheus scrape its targets and evaluate rules.
+  scrape_interval: 15s
   # How long should status reporter wait for Prometheus response (in seconds).
   request_timeout: 4
 

--- a/packaging/prometheus.spec
+++ b/packaging/prometheus.spec
@@ -1,7 +1,7 @@
 %define _tmpdir /tmp/prometheus
-%define _url    https://github.com/prometheus/prometheus/releases/download/v2.18.1/prometheus-2.18.1.linux-amd64.tar.gz
+%define _url    https://github.com/prometheus/prometheus/releases/download/v2.22.1/prometheus-2.22.1.linux-amd64.tar.gz
 Name:           prometheus
-Version:        2.18.1
+Version:        2.22.1
 Release:        1%{?dist}
 Summary:        The Prometheus monitoring system and time series database.
 Group:          Applications/Multimedia

--- a/packaging/prometheus_blackbox_exporter.spec
+++ b/packaging/prometheus_blackbox_exporter.spec
@@ -1,7 +1,7 @@
 %define _tmpdir /tmp/blackbox_exporter
-%define _url    https://github.com/prometheus/blackbox_exporter/releases/download/v0.16.0/blackbox_exporter-0.16.0.linux-amd64.tar.gz
+%define _url    https://github.com/prometheus/blackbox_exporter/releases/download/v0.18.0/blackbox_exporter-0.18.0.linux-amd64.tar.gz
 Name:           blackbox_exporter
-Version:        0.16.0
+Version:        0.18.0
 Release:        1%{?dist}
 Summary:        Prometheus blackbox_exporter
 Group:          Applications/Multimedia

--- a/packaging/prometheus_node_exporter.spec
+++ b/packaging/prometheus_node_exporter.spec
@@ -1,7 +1,7 @@
 %define _tmpdir /tmp/node_exporter
-%define _url    https://github.com/prometheus/node_exporter/releases/download/v1.0.0/node_exporter-1.0.0.linux-amd64.tar.gz
+%define _url    https://github.com/prometheus/node_exporter/releases/download/v1.0.1/node_exporter-1.0.1.linux-amd64.tar.gz
 Name:           node_exporter
-Version:        1.0.0
+Version:        1.0.1
 Release:        1%{?dist}
 Summary:        Prometheus node_exporter
 Group:          Applications/Multimedia


### PR DESCRIPTION
`scrape_interval` is a [Prometheus configuration parameter](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config) which defines how often should Prometheus scrape its targets.

Also used to set up `evaluation_interval` (frequency of rules evaluation).