### PR TITLE
RD-80 Use Prometheus rules to determine cluster status

### DIFF
--- a/cfy_manager/components/prometheus/config/alerts/manager.yml
+++ b/cfy_manager/components/prometheus/config/alerts/manager.yml
@@ -7,8 +7,12 @@ groups:
         expr: count by (host, monitor) (sum by (host, monitor) (probe_success) == {{ number_of_http_probes }})
       - record: manager_service_systemd
         expr: sum by (host, name) (node_systemd_unit_state{name=~"(cloudify-amqp-postgres|blackbox_exporter|cloudify-composer|cloudify-stage|haproxy|cloudify-mgmtworker|cloudify-restservice|node_exporter|prometheus|cloudify-syncthing|nginx).service", state="active"})
+        labels:
+          process_manager: systemd
       - record: manager_service_supervisord
         expr: sum by (host, name) (node_supervisord_up{name=~"(cloudify-amqp-postgres|blackbox_exporter|cloudify-composer|cloudify-stage|haproxy|cloudify-mgmtworker|cloudify-restservice|node_exporter|prometheus|cloudify-syncthing|nginx)"})
+        labels:
+          process_manager: supervisord
       - record: manager_service
         expr: manager_service_systemd or manager_service_supervisord
 

--- a/cfy_manager/components/prometheus/config/alerts/postgres.yml
+++ b/cfy_manager/components/prometheus/config/alerts/postgres.yml
@@ -7,8 +7,12 @@ groups:
         expr: pg_up{job="postgresql"} == 1 and up{job="postgresql"} == 1
       - record: postgres_service_systemd
         expr: sum by (host, name) (node_systemd_unit_state{name=~"(etcd|patroni|node_exporter|prometheus|postgres_exporter{% if all_in_one %}|postgresql-9.5{% endif %}|nginx).service", state="active"})
+        labels:
+          process_manager: systemd
       - record: postgres_service_supervisord
         expr: sum by (host, name) (node_supervisord_up{name=~"(etcd|patroni|node_exporter|prometheus|postgres_exporter{% if all_in_one %}|postgresql-9.5{% endif %}|nginx)"})
+        labels:
+          process_manager: supervisord
       - record: postgres_service
         expr: postgres_service_systemd or postgres_service_supervisord
 

--- a/cfy_manager/components/prometheus/config/alerts/rabbitmq.yml
+++ b/cfy_manager/components/prometheus/config/alerts/rabbitmq.yml
@@ -7,8 +7,12 @@ groups:
         expr: sum by(host, instance, job, monitor) (up{job="rabbitmq"}) == 1
       - record: rabbitmq_service_systemd
         expr: sum by (host, name) (node_systemd_unit_state{name=~"(node_exporter|prometheus|cloudify-rabbitmq|nginx).service", state="active"})
+        labels:
+          process_manager: systemd
       - record: rabbitmq_service_supervisord
         expr: sum by (host, name) (node_supervisord_up{name=~"(node_exporter|prometheus|cloudify-rabbitmq|nginx)"})
+        labels:
+          process_manager: supervisord
       - record: rabbitmq_service
         expr: rabbitmq_service_systemd or rabbitmq_service_supervisord
 

--- a/cfy_manager/components/prometheus/prometheus.py
+++ b/cfy_manager/components/prometheus/prometheus.py
@@ -636,8 +636,8 @@ def _deploy_alerts_configuration(number_of_http_probes, uninstalling):
 
 
 def _calculate_alert_for(scrape_interval):
-    if scrape_interval:
-        scrape_interval = '{0}'.format(scrape_interval).lower()
+    scrape_interval = '{0}'.format(scrape_interval).lower() if scrape_interval\
+        else ''
     m = re.match(r'^((\d+)s)?((\d+)ms)?', scrape_interval)
     if not m or not m.lastindex or m.lastindex < 1:
         return '15s'


### PR DESCRIPTION
Add `process_manager` labels to `*_service_*` Prometheus rules.