### PR TITLE
Shorten Prometheus scraping_interval in Docker image

### DIFF
--- a/.circleci/cluster/db_config.yaml
+++ b/.circleci/cluster/db_config.yaml
@@ -37,6 +37,7 @@ prometheus:
     # `password` is a placeholder and will be updated during config file rendering, based on postgresql_server.postgres_password
     password: ''
     sslmode: require
+  scape_interval: 5s
 
 services_to_install:
 - database_service

--- a/.circleci/cluster/db_config.yaml
+++ b/.circleci/cluster/db_config.yaml
@@ -37,7 +37,7 @@ prometheus:
     # `password` is a placeholder and will be updated during config file rendering, based on postgresql_server.postgres_password
     password: ''
     sslmode: require
-  scape_interval: 5s
+  scrape_interval: 5s
 
 services_to_install:
 - database_service

--- a/.circleci/cluster/manager1_config.yaml
+++ b/.circleci/cluster/manager1_config.yaml
@@ -39,7 +39,7 @@ prometheus:
   cert_path: /etc/cloudify/cert.pem
   key_path: /etc/cloudify/key.pem
   ca_path: /etc/cloudify/ca.pem
-  scape_interval: 5s
+  scrape_interval: 5s
 
 ssl_inputs:
   postgresql_client_cert_path: /etc/cloudify/postgres_client_cert.pem

--- a/.circleci/cluster/manager1_config.yaml
+++ b/.circleci/cluster/manager1_config.yaml
@@ -39,6 +39,7 @@ prometheus:
   cert_path: /etc/cloudify/cert.pem
   key_path: /etc/cloudify/key.pem
   ca_path: /etc/cloudify/ca.pem
+  scape_interval: 5s
 
 ssl_inputs:
   postgresql_client_cert_path: /etc/cloudify/postgres_client_cert.pem

--- a/.circleci/cluster/manager2_config.yaml
+++ b/.circleci/cluster/manager2_config.yaml
@@ -29,7 +29,7 @@ prometheus:
   cert_path: /etc/cloudify/prometheus_cert.pem
   key_path: /etc/cloudify/prometheus_key.pem
   ca_path: /etc/cloudify/ca.pem
-  scape_interval: 5s
+  scrape_interval: 5s
 
 ssl_inputs:
   postgresql_client_cert_path: /etc/cloudify/postgres_client_cert.pem

--- a/.circleci/cluster/manager2_config.yaml
+++ b/.circleci/cluster/manager2_config.yaml
@@ -29,6 +29,7 @@ prometheus:
   cert_path: /etc/cloudify/prometheus_cert.pem
   key_path: /etc/cloudify/prometheus_key.pem
   ca_path: /etc/cloudify/ca.pem
+  scape_interval: 5s
 
 ssl_inputs:
   postgresql_client_cert_path: /etc/cloudify/postgres_client_cert.pem

--- a/.circleci/cluster/queue1_config.yaml
+++ b/.circleci/cluster/queue1_config.yaml
@@ -20,7 +20,7 @@ prometheus:
   cert_path: /etc/cloudify/queue_cert.pem
   key_path: /etc/cloudify/queue_key.pem
   ca_path: /etc/cloudify/ca.pem
-  scape_interval: 5s
+  scrape_interval: 5s
 
 services_to_install:
  - queue_service

--- a/.circleci/cluster/queue1_config.yaml
+++ b/.circleci/cluster/queue1_config.yaml
@@ -20,6 +20,7 @@ prometheus:
   cert_path: /etc/cloudify/queue_cert.pem
   key_path: /etc/cloudify/queue_key.pem
   ca_path: /etc/cloudify/ca.pem
+  scape_interval: 5s
 
 services_to_install:
  - queue_service

--- a/.circleci/cluster/queue2_config.yaml
+++ b/.circleci/cluster/queue2_config.yaml
@@ -21,6 +21,7 @@ prometheus:
   cert_path: /etc/cloudify/queue_cert.pem
   key_path: /etc/cloudify/queue_key.pem
   ca_path: /etc/cloudify/ca.pem
+  scape_interval: 5s
 
 services_to_install:
  - queue_service

--- a/.circleci/cluster/queue2_config.yaml
+++ b/.circleci/cluster/queue2_config.yaml
@@ -21,7 +21,7 @@ prometheus:
   cert_path: /etc/cloudify/queue_cert.pem
   key_path: /etc/cloudify/queue_key.pem
   ca_path: /etc/cloudify/ca.pem
-  scape_interval: 5s
+  scrape_interval: 5s
 
 services_to_install:
  - queue_service

--- a/packaging/docker/config.yaml
+++ b/packaging/docker/config.yaml
@@ -14,6 +14,9 @@ sanity:
 postgresql_client:
   server_username: postgres
 
+prometheus:
+  scape_interval: 5s
+
 services_to_install:
   - database_service
   - queue_service

--- a/packaging/docker/config.yaml
+++ b/packaging/docker/config.yaml
@@ -15,7 +15,7 @@ postgresql_client:
   server_username: postgres
 
 prometheus:
-  scape_interval: 5s
+  scrape_interval: 5s
 
 services_to_install:
   - database_service


### PR DESCRIPTION
Shorten scraping and evaluation interval periods for Prometheus.  This
way a valid response for `cfy cluster status` is going to come faster.