### PR TITLE
RD-642 Use nginx.port to render composer monitoring target

### DIFF
--- a/cfy_manager/components/prometheus/prometheus.py
+++ b/cfy_manager/components/prometheus/prometheus.py
@@ -458,17 +458,28 @@ def _update_manager_targets(private_ip, uninstalling):
             is_premium_installed()
             and not config[COMPOSER]['skip_installation']
         )
+        nginx_port = config[NGINX].get('port')
+        if not nginx_port:
+            nginx_port = 80\
+                if config[MANAGER]['external_rest_protocol'].lower() == 'http'\
+                else 443
         if composer_installed:
             # Monitor composer directly and via nginx
             http_200_targets.append('http://127.0.0.1:3000/')
-            http_200_targets.append('http://{}/composer'.format(private_ip))
+            http_200_targets.append(
+                '{proto}://{private_ip}:{port}/composer'.format(
+                    proto=config[MANAGER]['external_rest_protocol'],
+                    private_ip=private_ip,
+                    port=nginx_port,
+                )
+            )
         # Monitor stage directly and via nginx
         http_200_targets.append('http://127.0.0.1:8088')
         http_200_targets.append(
             '{proto}://{public_ip}:{port}/'.format(
                 proto=config[MANAGER]['external_rest_protocol'],
                 public_ip=config[MANAGER][PUBLIC_IP],
-                port=config[MANAGER]['external_rest_port'],
+                port=nginx_port,
             )
         )
         # Monitor cloudify's internal port


### PR DESCRIPTION
During Prometheus installation HTTP endpoints to be monitored are rendered.  Until now we have used `manager.external_rest_port` to render Cloudify Stage's endpoint, and default (80) port for Cloudify Composer.  This patch changes that as from now on `nginx.port` will be used for both of these.

Also `private_ip` endpoints would be used as http monitoring targets (instead of the mixture of `private_ip` and `public_ip`)