### PR TITLE
RD-597 Reconfigure manager on container restarts

### DIFF
--- a/cfy_manager/components/restservice/scripts/update_stored_manager.py
+++ b/cfy_manager/components/restservice/scripts/update_stored_manager.py
@@ -78,10 +78,11 @@ if __name__ == '__main__':
     with open(args.input) as f:
         inputs = json.load(f)
 
-    config.instance.load_configuration()
+    config.instance.load_configuration(from_db=False)
     with setup_flask_app(
         manager_ip=config.instance.postgresql_host,
         hash_salt=config.instance.security_hash_salt,
         secret_key=config.instance.security_secret_key
     ).app_context():
+        config.instance.load_configuration()
         main(inputs['manager'])

--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -1205,9 +1205,6 @@ def image_starter(verbose=False, config_file=None):
         config_write_required=False,
         config_file=config_file,
     )
-    if _are_components_configured():
-        logger.info('Components already configured - nothing to do')
-        return
     config.load_config(config_file)
     command = [sys.executable, '-m', 'cfy_manager.main', 'configure']
     private_ip = config[MANAGER].get(PRIVATE_IP)


### PR DESCRIPTION
When the manager is rebooted and image-starter runs again, run
configure again. That will update the manager with all ip/config
changes.