### PR TITLE
RD-419 Update configuration for wait on restart service for nginx

### DIFF
--- a/cfy_manager/components/nginx/config/supervisord/wait_on_restart.conf
+++ b/cfy_manager/components/nginx/config/supervisord/wait_on_restart.conf
@@ -1,3 +1,4 @@
 [program:wait_on_restart]
 autostart=false
+startsecs=0
 command=/etc/cloudify/wait_on_restart.sh

--- a/cfy_manager/components/nginx/scripts/wait_on_restart.sh
+++ b/cfy_manager/components/nginx/scripts/wait_on_restart.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 set -e
 echo Restarting nginx
-sleep 1
-/usr/bin/supervisorctl -c /etc/supervisord.conf restart nginx
+/bin/bash -c "sleep 1 && supervisorctl -c /etc/supervisord.conf restart nginx > /dev/null 2>&1 &"


### PR DESCRIPTION
CLI support to control enable/disable ssl using `cfy ssl enable` && `cfy ssl disabled` and also to get the status `cfy ssl status`. On the Manager API side the way how ssl is enabled/disabled is by calling [manager.py](https://github.com/cloudify-cosmo/cloudify-manager/blob/master/rest-service/manager_rest/rest/resources_v3_1/manager.py#L75) where the [set-manager-ssl.py](https://github.com/cloudify-cosmo/cloudify-manager/blob/master/packaging/rest-service/files/opt/manager/scripts/set-manager-ssl.py) is update the nignx configuration file to replace http/https files to make it work with/out ssl.

In order to make the changes take effect immediately a restart to nginx is required but this should be done after the caller to the rest api clean up to avoid unexpected results. In systemd this get achieved using `systemd-run` with `--on-active` option which make the command run after 1 second to make sure the caller of the rest is finished. 

In supervsiord we need to apply the same principle and thats the reason why the changes included for this PR where the actual restart for the nignx will be happened in the background after 1 second. With this we can make sure that the caller just trigger the wait_for_restart service and then the actual restart will happened in the background. 