### PR TITLE
RD-685 Update the log level to debug for supervisord and update patro…

### DIFF
--- a/cfy_manager/components/postgresql_server/config/supervisord/patroni_startup_check.conf
+++ b/cfy_manager/components/postgresql_server/config/supervisord/patroni_startup_check.conf
@@ -1,2 +1,4 @@
 [program:patroni_startup_check]
+autostart=false
+startsecs=0
 command=/opt/patroni/bin/patroni_startup_check

--- a/packaging/docker/supervisord.conf
+++ b/packaging/docker/supervisord.conf
@@ -1,5 +1,6 @@
 [supervisord]
 logfile = /var/log/cloudify/supervisord.log
+loglevel = debug
 
 [unix_http_server]
 file = /tmp/supervisor.sock


### PR DESCRIPTION
Currently, when installing cloudify with cluster mode for containers, the following issues come to the surface:

1. Stopping db node container and then start it make that node in dead state because of memory ram issues

1. It turned out that, the service required for checking the patroni startup to make sure its completed or not never exit, because it keep looking for a message in the log file under `/var/log/cloudify/suprvisord.log` where it never printed there because the log level set is not marked as debug `debug`

The main solution for this issue is to mark the loglevel to debug and also to update the settings for `patroni_startup_check` service to never start by its own since its triggered from whenever configuration for db is happened  