### PR TITLE
Starter: don't overwrite the config

### DIFF
--- a/cfy_manager/components/restservice/db.py
+++ b/cfy_manager/components/restservice/db.py
@@ -288,7 +288,7 @@ def insert_manager(configs):
 
 
 def update_stored_manager(configs=None):
-    logger.notice('Creating AMQP resources...')
+    logger.notice('Updating stored manager...')
     args = {'manager': _get_manager()}
 
     run_script('update_stored_manager.py', args, configs=configs)

--- a/cfy_manager/config.py
+++ b/cfy_manager/config.py
@@ -127,8 +127,6 @@ class Config(CommentedMap):
             )
 
     def dump_config(self):
-        if not self.get('save_config', True):
-            return
         self.pop(self.TEMP_PATHS, None)
         try:
             with self._own_config_file():

--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -597,8 +597,9 @@ def _create_initial_configure_files():
             touch(os.path.join(INITIAL_CONFIGURE_DIR, service_name))
 
 
-def _finish_configuration(only_install):
-    config.dump_config()
+def _finish_configuration(only_install, save_config=True):
+    if save_config and config.get('save_config', True):
+        config.dump_config()
     remove_temp_files()
     _create_initial_install_files()
     if not only_install:
@@ -864,6 +865,7 @@ def configure(verbose=False,
               public_ip=None,
               admin_password=None,
               config_file=None,
+              skip_config_save=False,
               clean_db=False):
     """ Configure Cloudify Manager """
 
@@ -894,7 +896,7 @@ def configure(verbose=False,
 
     config[UNCONFIGURED_INSTALL] = False
     logger.notice('Configuration finished successfully!')
-    _finish_configuration(only_install=False)
+    _finish_configuration(only_install=False, save_config=not skip_config_save)
 
 
 def _all_main_services_removed():
@@ -1208,7 +1210,8 @@ def image_starter(verbose=False, config_file=None):
         config_file=config_file,
     )
     config.load_config(config_file)
-    command = [sys.executable, '-m', 'cfy_manager.main', 'configure']
+    command = [sys.executable, '-m', 'cfy_manager.main', 'configure',
+               '--skip-config-save']
     private_ip = config[MANAGER].get(PRIVATE_IP)
     if not private_ip:
         private_ip = _guess_private_ip()


### PR DESCRIPTION
Add a flag for `cfy_manager configure` that skips overwriting
the config file, and use it in the implicit `configure` called from
cloudify-starter.

I very much don't like overwriting the config file.