### PR TITLE
RD-673 Refactor the "initialize db" flow

### DIFF
--- a/cfy_manager/components/restservice/db.py
+++ b/cfy_manager/components/restservice/db.py
@@ -108,8 +108,8 @@ def _create_database(db_name, user):
         'ALTER DATABASE {} OWNER TO {}'.format(db_name, user),
         'server_db_name', logger)
     run_psql_command(
-         'GRANT ALL PRIVILEGES ON DATABASE {} to {}'.format(db_name, user),
-         'server_db_name', logger)
+        'GRANT ALL PRIVILEGES ON DATABASE {} to {}'.format(db_name, user),
+        'server_db_name', logger)
 
 
 def _get_provider_context():
@@ -329,27 +329,13 @@ def check_db_exists():
     return config[POSTGRESQL_CLIENT]['cloudify_db_name'] in dbs
 
 
-def manager_is_in_db():
+def get_managers():
     result = run_psql_command(
-        "SELECT COUNT(*) FROM managers where hostname='{0}'".format(
-            config[MANAGER][HOSTNAME],
-        ),
+        'SELECT hostname FROM managers',
         'cloudify_db_name',
-        logger,
+        logger
     )
-
-    # As the name is unique, there can only ever be at most 1 entry with the
-    # expected name, and if there is then the manager is in the db.
-    return int(result) == 1
-
-
-def get_manager_count():
-    result = run_psql_command(
-        "SELECT COUNT(*) FROM managers",
-        'cloudify_db_name',
-        logger,
-    )
-    return int(result)
+    return [line.strip() for line in result.split('\n') if line.strip()]
 
 
 def validate_schema_version(configs):

--- a/cfy_manager/components/restservice/db.py
+++ b/cfy_manager/components/restservice/db.py
@@ -300,6 +300,13 @@ def update_stored_manager(configs=None):
     logger.notice('AMQP resources successfully created')
 
 
+def get_monitoring_config():
+    output = run_script('get_monitoring_config.py', configs={
+        'rest_config': constants.REST_CONFIG_PATH,
+    })
+    return json.loads(output)
+
+
 def check_db_exists():
     # Get the list of databases
     result = run_psql_command(

--- a/cfy_manager/components/restservice/db.py
+++ b/cfy_manager/components/restservice/db.py
@@ -284,12 +284,7 @@ def _get_manager():
 def insert_manager(configs):
     logger.notice('Registering manager in the DB...')
     args = {'manager': _get_manager()}
-    out = run_script('create_tables_and_add_defaults.py', args, configs)
-    if out:
-        out_dict = json.loads(out)
-        if 'cluster_nodes_config' in out_dict:
-            return (out_dict.get('cluster_nodes_config'),
-                    out_dict.get('rabbitmq_ca_cert_path'),)
+    run_script('create_tables_and_add_defaults.py', args, configs)
 
 
 def update_stored_manager(configs=None):

--- a/cfy_manager/components/restservice/restservice.py
+++ b/cfy_manager/components/restservice/restservice.py
@@ -268,12 +268,9 @@ class RestService(BaseComponent):
         if config[MANAGER][HOSTNAME] in managers:
             db.update_stored_manager(configs)
         else:
-            cluster_cfg_fn, rabbitmq_ca_fn = db.insert_manager(configs)
+            db.insert_manager(configs)
             if len(managers) > 0:
                 self._join_cluster(configs)
-                if MONITORING_SERVICE in config.get(SERVICES_TO_INSTALL):
-                    self._prepare_cluster_config_update(cluster_cfg_fn,
-                                                        rabbitmq_ca_fn)
 
     def _initialize_db(self, configs):
         logger.info('DB not initialized, creating DB...')

--- a/cfy_manager/components/restservice/restservice.py
+++ b/cfy_manager/components/restservice/restservice.py
@@ -278,7 +278,6 @@ class RestService(BaseComponent):
     def _initialize_db(self, configs):
         logger.info('DB not initialized, creating DB...')
         self._generate_passwords()
-        certificates.handle_ca_cert(logger)
         db.prepare_db()
         db.populate_db(configs)
 
@@ -515,6 +514,7 @@ class RestService(BaseComponent):
         self._make_paths()
         self._configure_restservice()
         service.configure('cloudify-restservice')
+        certificates.handle_ca_cert(logger)
         self._configure_db()
         if is_premium_installed():
             self._join_cluster_setup()

--- a/cfy_manager/components/restservice/restservice.py
+++ b/cfy_manager/components/restservice/restservice.py
@@ -268,9 +268,9 @@ class RestService(BaseComponent):
         if config[MANAGER][HOSTNAME] in managers:
             db.update_stored_manager(configs)
         else:
-            db.insert_manager(configs)
+            cluster_cfg_fn, rabbitmq_ca_fn = db.insert_manager(configs)
             if len(managers) > 0:
-                cluster_cfg_fn, rabbitmq_ca_fn = self._join_cluster(configs)
+                self._join_cluster(configs)
                 if MONITORING_SERVICE in config.get(SERVICES_TO_INSTALL):
                     self._prepare_cluster_config_update(cluster_cfg_fn,
                                                         rabbitmq_ca_fn)
@@ -322,7 +322,6 @@ class RestService(BaseComponent):
         self._validate_cluster_join()
         config[CLUSTER_JOIN] = True
         certificates.handle_ca_cert(logger, generate_if_missing=False)
-        return db.insert_manager(configs)
 
     def _generate_password(self, length=12):
         chars = string.ascii_lowercase + string.ascii_uppercase + string.digits

--- a/cfy_manager/components/restservice/scripts/create_tables_and_add_defaults.py
+++ b/cfy_manager/components/restservice/scripts/create_tables_and_add_defaults.py
@@ -17,7 +17,6 @@
 from __future__ import print_function
 
 import os
-from os.path import isfile
 import sys
 import json
 import atexit
@@ -168,35 +167,6 @@ def _insert_manager(config):
     sm.put(inst)
 
 
-def _prepare_config_for_monitoring():
-    sm = get_storage_manager()
-    cfg = {}
-    rabbitmq_nodes = sm.list(models.RabbitMQBroker)
-    if len(rabbitmq_nodes) > 0:
-        tmp_ca_cert_path = rabbitmq_nodes[0].write_ca_cert()
-        if isfile(tmp_ca_cert_path):
-            RETURN_DICT['rabbitmq_ca_cert_path'] = tmp_ca_cert_path
-        cfg['rabbitmq'] = {
-            'cluster_members': {}
-        }
-        for node in rabbitmq_nodes:
-            cfg['rabbitmq']['cluster_members'][node.name] = {
-                'networks': {'default': node.private_ip}
-            }
-    postgresql_server_nodes = sm.list(models.DBNodes)
-    if len(postgresql_server_nodes) > 0:
-        cfg['postgresql_server'] = {'cluster': {'nodes': {}}}
-        for node in postgresql_server_nodes:
-            cfg['postgresql_server']['cluster']['nodes'][node.name] = {
-                'ip': node.private_ip
-            }
-    if not cfg:
-        return
-    with tempfile.NamedTemporaryFile(delete=False, mode='w') as fp:
-        json.dump(cfg, fp)
-        RETURN_DICT['cluster_nodes_config'] = fp.name
-
-
 def _insert_cert(cert, name):
     sm = get_storage_manager()
     inst = models.Certificate(
@@ -315,7 +285,5 @@ if __name__ == '__main__':
         _insert_db_nodes(script_config['db_nodes'])
     if script_config.get('usage_collector'):
         _insert_usage_collector(script_config['usage_collector'])
-    if script_config.get('manager'):
-        _prepare_config_for_monitoring()
 
     print(json.dumps(RETURN_DICT))

--- a/cfy_manager/components/restservice/scripts/create_tables_and_add_defaults.py
+++ b/cfy_manager/components/restservice/scripts/create_tables_and_add_defaults.py
@@ -40,8 +40,6 @@ logger = \
     logging.getLogger('[{0}]'.format('create_tables_and_add_defaults'.upper()))
 CA_CERT_PATH = '/etc/cloudify/ssl/cloudify_internal_ca_cert.pem'
 
-RETURN_DICT = {}
-
 
 def _init_db_tables(db_migrate_dir):
     logger.info('Setting up a Flask app')
@@ -189,42 +187,6 @@ def _add_provider_context(context):
     sm.put(provider_context)
 
 
-def _add_manager_status_reporter_user():
-    logger.info('Creating the Manager Status Reporter user, default tenant '
-                'and security roles')
-    user = storage_utils.create_status_reporter_user_and_assign_role(
-        script_config['manager_status_reporter_username'],
-        script_config['manager_status_reporter_password'],
-        script_config['manager_status_reporter_role'],
-        script_config['manager_status_reporter_user_id']
-    )
-    RETURN_DICT['manager_status_reporter_token'] = user.api_token
-
-
-def _add_broker_status_reporter_user():
-    logger.info('Creating the Queue Status Reporter user, default tenant and '
-                'security roles')
-    user = storage_utils.create_status_reporter_user_and_assign_role(
-        script_config['broker_status_reporter_username'],
-        script_config['broker_status_reporter_password'],
-        script_config['broker_status_reporter_role'],
-        script_config['broker_status_reporter_user_id']
-    )
-    RETURN_DICT['broker_status_reporter_token'] = user.api_token
-
-
-def _add_db_status_reporter_user():
-    logger.info('Creating the DB Status Reporter user, default tenant and '
-                'security roles')
-    user = storage_utils.create_status_reporter_user_and_assign_role(
-        script_config['db_status_reporter_username'],
-        script_config['db_status_reporter_password'],
-        script_config['db_status_reporter_role'],
-        script_config['db_status_reporter_user_id']
-    )
-    RETURN_DICT['db_status_reporter_token'] = user.api_token
-
-
 def file_path(path):
     if os.path.exists(path):
         return path
@@ -261,15 +223,6 @@ if __name__ == '__main__':
             and script_config.get('admin_password')):
         amqp_manager = _get_amqp_manager(script_config)
         _add_default_user_and_tenant(amqp_manager, script_config)
-    if (script_config.get('manager_status_reporter_username')
-            and script_config.get('manager_status_reporter_password')):
-        _add_manager_status_reporter_user()
-    if (script_config.get('broker_status_reporter_username')
-            and script_config.get('broker_status_reporter_password')):
-        _add_broker_status_reporter_user()
-    if (script_config.get('db_status_reporter_username')
-            and script_config.get('db_status_reporter_password')):
-        _add_db_status_reporter_user()
     if script_config.get('config'):
         _insert_config(script_config['config'])
     if script_config.get('rabbitmq_brokers'):
@@ -285,5 +238,3 @@ if __name__ == '__main__':
         _insert_db_nodes(script_config['db_nodes'])
     if script_config.get('usage_collector'):
         _insert_usage_collector(script_config['usage_collector'])
-
-    print(json.dumps(RETURN_DICT))

--- a/cfy_manager/components/restservice/scripts/get_monitoring_config.py
+++ b/cfy_manager/components/restservice/scripts/get_monitoring_config.py
@@ -1,0 +1,41 @@
+from __future__ import print_function
+import json
+
+from manager_rest import config
+from manager_rest.storage import db, models, get_storage_manager  # NOQA
+from manager_rest.flask_utils import setup_flask_app
+
+
+def _prepare_config_for_monitoring():
+    sm = get_storage_manager()
+    cfg = {}
+    rabbitmq_nodes = sm.list(models.RabbitMQBroker)
+    if len(rabbitmq_nodes) > 0:
+        tmp_ca_cert_path = rabbitmq_nodes[0].write_ca_cert()
+        cfg['rabbitmq'] = {
+            'ca_path': tmp_ca_cert_path,
+            'cluster_members': {}
+        }
+        for node in rabbitmq_nodes:
+            cfg['rabbitmq']['cluster_members'][node.name] = {
+                'networks': {'default': node.private_ip}
+            }
+    postgresql_server_nodes = sm.list(models.DBNodes)
+    if len(postgresql_server_nodes) > 0:
+        cfg['postgresql_server'] = {'cluster': {'nodes': {}}}
+        for node in postgresql_server_nodes:
+            cfg['postgresql_server']['cluster']['nodes'][node.name] = {
+                'ip': node.private_ip
+            }
+    return cfg
+
+
+if __name__ == '__main__':
+    config.instance.load_configuration(from_db=False)
+    setup_flask_app(
+        manager_ip=config.instance.postgresql_host,
+        hash_salt=config.instance.security_hash_salt,
+        secret_key=config.instance.security_secret_key
+    )
+    monitoring_config = _prepare_config_for_monitoring()
+    print(json.dumps(monitoring_config))

--- a/cfy_manager/components/sanity/sanity.py
+++ b/cfy_manager/components/sanity/sanity.py
@@ -19,7 +19,7 @@ import uuid
 import pkg_resources
 from contextlib import contextmanager
 
-from ..restservice.db import get_manager_count
+from ..restservice.db import get_managers
 from ..base_component import BaseComponent
 from ..service_names import SANITY
 from ...logger import get_logger
@@ -85,7 +85,7 @@ class Sanity(BaseComponent):
     def configure(self):
         # This is start-like, but should only happen at install time, so it
         # is using configure instead
-        if get_manager_count() > 1:
+        if len(get_managers()) > 1:
             logger.notice('Not running the sanity check: part of a cluster')
             return
         with self.sanity_check_mode():


### PR DESCRIPTION
The "is manager in db" check is not enough for assuming that we're
in a cluster. Instead, look at how many managers we have, and only
assume we're in a cluster if there's already a manager other than us.

Also rework the db utils to just return the hostnames, instead of
a separate "is hostname in db" and "get count" utils.