### PR TITLE
openssl verify: additionally pass the cert as untrusted

### DIFF
--- a/cfy_manager/components/validations.py
+++ b/cfy_manager/components/validations.py
@@ -310,7 +310,12 @@ def _check_ssl_file(filename, kind='Key', password=None):
 
 def _check_signed_by(ca_filename, cert_filename):
     ca_check_command = [
-        'openssl', 'verify', '-CAfile', ca_filename, cert_filename
+        'openssl', 'verify',
+        '-CAfile', ca_filename,
+        # also give openssl the cert itself so that it can look up
+        # intermediaries, if any
+        '-untrusted', cert_filename,
+        cert_filename
     ]
     try:
         sudo(ca_check_command)


### PR DESCRIPTION
Passing the cert in `-untrusted` makes openssl look at all certs in that
file when verifying the chain, so it will find intermediaries there.
It will still be verified against the CA.