### PR TITLE
CYBL-1080 Stop monitoring external endpoints

### DIFF
--- a/cfy_manager/components/prometheus/prometheus.py
+++ b/cfy_manager/components/prometheus/prometheus.py
@@ -458,30 +458,11 @@ def _update_manager_targets(private_ip, uninstalling):
             is_premium_installed()
             and not config[COMPOSER]['skip_installation']
         )
-        nginx_port = config[NGINX].get('port')
-        if not nginx_port:
-            nginx_port = 80\
-                if config[MANAGER]['external_rest_protocol'].lower() == 'http'\
-                else 443
         if composer_installed:
             # Monitor composer directly and via nginx
             http_200_targets.append('http://127.0.0.1:3000/')
-            http_200_targets.append(
-                '{proto}://{private_ip}:{port}/composer'.format(
-                    proto=config[MANAGER]['external_rest_protocol'],
-                    private_ip=private_ip,
-                    port=nginx_port,
-                )
-            )
         # Monitor stage directly and via nginx
         http_200_targets.append('http://127.0.0.1:8088')
-        http_200_targets.append(
-            '{proto}://{public_ip}:{port}/'.format(
-                proto=config[MANAGER]['external_rest_protocol'],
-                public_ip=config[MANAGER][PUBLIC_IP],
-                port=nginx_port,
-            )
-        )
         # Monitor cloudify's internal port
         http_200_targets.append('https://{}:53333/'.format(private_ip))
 


### PR DESCRIPTION
There is not much more information from checking the same service (Stage
and Composer) twice: first directly and then via nginx proxy.  Also the
configuration of these services can change (esp. when user decides to
re-generate CA certs or use his/her own certs).  This is why Status
Reporter will no longer monitor `http(s)://example.com/composer` and
`http(s)://example.com/` endpoints.