### PR TITLE
RD-730 Prometheus update_config: not on AIO

### DIFF
--- a/cfy_manager/components/prometheus/prometheus.py
+++ b/cfy_manager/components/prometheus/prometheus.py
@@ -339,7 +339,7 @@ def _update_config():
         config[PROMETHEUS][BLACKBOX_EXPORTER].update(
             {'ca_cert_path': config.get(CONSTANTS, {}).get('ca_cert_path')})
 
-    if _installing_manager():
+    if common.is_manager_service_only_installed():
         cluster_cfg = get_monitoring_config()
         if (cluster_cfg.get(POSTGRESQL_SERVER, {}).get('cluster',
                                                        {}).get('nodes') and


### PR DESCRIPTION
This part of code used to be run only on clusters, but we recently
changed it to be run "if manager is installed", which also includes
AIO.

But before, it didn't run on AIO, and now, it must not run on AIO
either, because then it'll insert `.cluster.nodes` into the config.

Let's change it to check "if manager ONLY is installed", which
will catch both clusters, and also an external-db/external-rabbit
situation as well, which we want to monitor too