### PR TITLE
RD-793 scripts: load config in app context

### DIFF
--- a/cfy_manager/networks/scripts/update-manager-networks.py
+++ b/cfy_manager/networks/scripts/update-manager-networks.py
@@ -37,6 +37,7 @@ def _update_manager_networks(hostname, networks, with_broker=False):
     :param networks: a dict containing the new networks
     """
     with setup_flask_app().app_context():
+        config.instance.load_configuration()
         sm = get_storage_manager()
 
         filters = {}
@@ -80,6 +81,5 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     config.instance.load_from_file(RESTSERVICE_CONFIG_PATH)
-    config.instance.load_configuration()
     _update_manager_networks(
         args.hostname, json.loads(args.networks), with_broker=args.broker)

--- a/cfy_manager/scripts/update-admin-password.py
+++ b/cfy_manager/scripts/update-admin-password.py
@@ -15,6 +15,7 @@ SECURITY_CONFIG_PATH = "/opt/manager/rest-security.conf"
 def _update_admin_password(new_password):
     """Update the admin user's password."""
     with setup_flask_app().app_context():
+        config.instance.load_configuration()
         user = user_datastore.get_user('admin')
         user.password = hash_password(new_password)
         # Unlock account
@@ -34,5 +35,4 @@ if __name__ == '__main__':
 
     config.instance.load_from_file(RESTSERVICE_CONFIG_PATH)
     config.instance.load_from_file(SECURITY_CONFIG_PATH, namespace='security')
-    config.instance.load_configuration()
     _update_admin_password(args.new_password)


### PR DESCRIPTION
This change added in order to make sure that any script call flask app outside the rest service must call [load_configuration](https://github.com/cloudify-cosmo/cloudify-manager/blob/master/rest-service/manager_rest/config.py#L142) after the flask app is setup or inside the flask app context as the some method like [_find_db_host](https://github.com/cloudify-cosmo/cloudify-manager/blob/b78ba2931783acf76bcbf44d6154389022df4165/rest-service/manager_rest/config.py#L329) used that current app and in case any script tries to call `config.instance.load_configuration()` before setup the flask app it will fail with the following error
```
    config.instance.load_configuration()
  File "/opt/manager/env/lib64/python3.6/site-packages/manager_rest/config.py", line 147, in load_configuration
    self.load_from_db()
  File "/opt/manager/env/lib64/python3.6/site-packages/manager_rest/config.py", line 165, in load_from_db
    engine = create_engine(self.db_url)
  File "/opt/manager/env/lib64/python3.6/site-packages/manager_rest/config.py", line 285, in db_url
    host = self._find_db_host(self.postgresql_host)
  File "/opt/manager/env/lib64/python3.6/site-packages/manager_rest/config.py", line 329, in _find_db_host
    current_app.logger.debug(
  File "/opt/manager/env/lib64/python3.6/site-packages/werkzeug/local.py", line 347, in __getattr__
    return getattr(self._get_current_object(), name)
  File "/opt/manager/env/lib64/python3.6/site-packages/werkzeug/local.py", line 306, in _get_current_object
    return self.__local()
  File "/opt/manager/env/lib64/python3.6/site-packages/flask/globals.py", line 52, in _find_app
    raise RuntimeError(_app_ctx_err_msg)
RuntimeError: Working outside of application context.
```