### PR TITLE
RD-742 Fix replace certificates script

### DIFF
--- a/cfy_manager/components/restservice/scripts/replace_certs_on_db.py
+++ b/cfy_manager/components/restservice/scripts/replace_certs_on_db.py
@@ -45,7 +45,7 @@ def update_cert(cert_path, name):
 
 
 def init_flask_app():
-    config.instance.load_configuration()
+    config.instance.load_configuration(from_db=False)
     setup_flask_app(
         manager_ip=config.instance.postgresql_host,
         hash_salt=config.instance.security_hash_salt,


### PR DESCRIPTION
Currently, the replace certificates procedure is failing with the following error: 
`RuntimeError: Working outside of application context.`. 
This happens due to [this line](https://github.com/cloudify-cosmo/cloudify-manager/blob/master/rest-service/manager_rest/config.py#L329) that tries to get the current app but fails. 

In order to prevent it, we pass to [load_configuration](https://github.com/cloudify-cosmo/cloudify-manager-install/blob/master/cfy_manager/components/restservice/scripts/replace_certs_on_db.py#L48) the parameter `from_db=False`, and then it doesn't reach this code. 