### PR TITLE
RD-821 monitoring: stop overwriting the config

### DIFF
--- a/cfy_manager/components/prometheus/prometheus.py
+++ b/cfy_manager/components/prometheus/prometheus.py
@@ -340,23 +340,45 @@ def _update_config():
         config[PROMETHEUS][BLACKBOX_EXPORTER].update(
             {'ca_cert_path': config.get(CONSTANTS, {}).get('ca_cert_path')})
 
+
+def _get_cluster_config():
+    """Cluster setup for setting up monitoring targets.
+
+    Based on config.yaml, but with fallback to reading nodes stored
+    in the db (on manager-only nodes).
+    """
+    try:
+        db_nodes = config[POSTGRESQL_SERVER]['cluster']['nodes']
+    except KeyError:
+        db_nodes = []
+    try:
+        rabbitmq_ca = config[RABBITMQ]['ca_path']
+    except KeyError:
+        rabbitmq_ca = None
+    try:
+        rabbitmq_nodes = config[RABBITMQ]['cluster_members']
+    except KeyError:
+        rabbitmq_nodes = []
+
     if common.is_manager_service_only_installed():
         cluster_cfg = get_monitoring_config()
-        if (cluster_cfg.get(POSTGRESQL_SERVER, {}).get('cluster',
-                                                       {}).get('nodes') and
-                not config.get(POSTGRESQL_SERVER, {}).get('cluster',
-                                                          {}).get('nodes')):
-            config[POSTGRESQL_SERVER]['cluster'].update({
-                'nodes': cluster_cfg[POSTGRESQL_SERVER]['cluster']['nodes']
-            })
-        if (cluster_cfg.get('RABBITMQ', {}).get('ca_path') and
-                not config.get(RABBITMQ, {}).get('ca_path')):
-            config[RABBITMQ]['ca_path'] = cluster_cfg[RABBITMQ]['ca_path']
-        if (cluster_cfg.get(RABBITMQ, {}).get('cluster_members') and
-                not config.get(RABBITMQ, {}).get('cluster_members')):
-            config[RABBITMQ].update({
-                'cluster_members': cluster_cfg[RABBITMQ]['cluster_members']
-            })
+        if not db_nodes:
+            db_nodes = cluster_cfg[POSTGRESQL_SERVER]['cluster']['nodes']
+        if not rabbitmq_ca:
+            rabbitmq_ca = join(PROMETHEUS_CONFIG_DIR, 'rabbitmq_ca.pem')
+            common.move(
+                cluster_cfg[RABBITMQ]['ca_path'],
+                rabbitmq_ca
+            )
+            common.chown('cfyuser', 'cfyuser', rabbitmq_ca)
+        if not rabbitmq_nodes:
+            rabbitmq_nodes = cluster_cfg[RABBITMQ]['cluster_members']
+
+    return {
+        'db_nodes': db_nodes,
+        'rabbitmq_ca': rabbitmq_ca,
+        'rabbitmq_nodes': rabbitmq_nodes
+    }
 
 
 def _update_prometheus_configuration(uninstalling=False):
@@ -372,8 +394,11 @@ def _update_prometheus_configuration(uninstalling=False):
     _update_base_targets(private_ip, uninstalling)
 
     if common.is_installed(MANAGER_SERVICE):
-        http_probes_count = _update_manager_targets(private_ip, uninstalling)
-        _deploy_alerts_configuration(http_probes_count, uninstalling)
+        cluster_config = _get_cluster_config()
+        http_probes_count = _update_manager_targets(
+            private_ip, cluster_config, uninstalling)
+        _deploy_alerts_configuration(
+            http_probes_count, cluster_config, uninstalling)
 
     if common.is_installed(DATABASE_SERVICE):
         _update_local_postgres_targets(private_ip, uninstalling)
@@ -435,7 +460,7 @@ def _update_local_postgres_targets(private_ip, uninstalling):
                     local_postgres_targets, local_postgres_labels)
 
 
-def _update_manager_targets(private_ip, uninstalling):
+def _update_manager_targets(private_ip, cluster_config, uninstalling):
     http_200_targets = []
     http_200_labels = {}
     http_401_targets = []
@@ -471,16 +496,14 @@ def _update_manager_targets(private_ip, uninstalling):
 
         # Monitor remote rabbit nodes
         use_rabbit_host = config[RABBITMQ]['use_hostnames_in_db']
-        for host, rabbit in config[RABBITMQ]['cluster_members'].items():
+        for host, rabbit in cluster_config['rabbitmq_nodes'].items():
             target = host if use_rabbit_host else rabbit['networks']['default']
             if not (_installing_rabbit() and target == private_ip):
-                rabbit_targets.append(
-                    target + ':' + monitoring_port)
+                rabbit_targets.append(target + ':' + monitoring_port)
 
         # Monitor remote postgres nodes
-        for node in config[POSTGRESQL_SERVER]['cluster']['nodes'].values():
-            postgres_targets.append(
-                node['ip'] + ':' + monitoring_port)
+        for node in cluster_config['db_nodes'].values():
+            postgres_targets.append(node['ip'] + ':' + monitoring_port)
 
         # Monitor remote manager nodes
         if config.get(CLUSTER_JOIN):
@@ -537,7 +560,8 @@ def _deploy_targets(destination, targets, labels):
     )
 
 
-def _deploy_alerts_configuration(number_of_http_probes, uninstalling):
+def _deploy_alerts_configuration(number_of_http_probes, cluster_config,
+                                 uninstalling):
     render_context = {
         'number_of_http_probes': number_of_http_probes,
         'all_in_one': common.is_all_in_one_manager(),
@@ -557,14 +581,14 @@ def _deploy_alerts_configuration(number_of_http_probes, uninstalling):
         else:
             manager_hosts.append(config[MANAGER][PRIVATE_IP])
 
-        if config[POSTGRESQL_SERVER]['cluster']['nodes'].values():
-            for node in config[POSTGRESQL_SERVER]['cluster']['nodes'].values():
+        if cluster_config['db_nodes']:
+            for node in cluster_config['db_nodes'].values():
                 postgres_hosts.append(node['ip'])
         else:
             postgres_hosts.append(config[MANAGER][PRIVATE_IP])
 
         use_rabbit_host = config[RABBITMQ]['use_hostnames_in_db']
-        for host, rabbit in config[RABBITMQ]['cluster_members'].items():
+        for host, rabbit in cluster_config['rabbitmq_nodes'].items():
             rabbitmq_hosts.append(host if use_rabbit_host
                                   else rabbit['networks']['default'])
 

--- a/cfy_manager/components/prometheus/prometheus.py
+++ b/cfy_manager/components/prometheus/prometheus.py
@@ -352,10 +352,6 @@ def _get_cluster_config():
     except KeyError:
         db_nodes = []
     try:
-        rabbitmq_ca = config[RABBITMQ]['ca_path']
-    except KeyError:
-        rabbitmq_ca = None
-    try:
         rabbitmq_nodes = config[RABBITMQ]['cluster_members']
     except KeyError:
         rabbitmq_nodes = []
@@ -364,19 +360,11 @@ def _get_cluster_config():
         cluster_cfg = get_monitoring_config()
         if not db_nodes:
             db_nodes = cluster_cfg[POSTGRESQL_SERVER]['cluster']['nodes']
-        if not rabbitmq_ca:
-            rabbitmq_ca = join(PROMETHEUS_CONFIG_DIR, 'rabbitmq_ca.pem')
-            common.move(
-                cluster_cfg[RABBITMQ]['ca_path'],
-                rabbitmq_ca
-            )
-            common.chown('cfyuser', 'cfyuser', rabbitmq_ca)
         if not rabbitmq_nodes:
             rabbitmq_nodes = cluster_cfg[RABBITMQ]['cluster_members']
 
     return {
         'db_nodes': db_nodes,
-        'rabbitmq_ca': rabbitmq_ca,
         'rabbitmq_nodes': rabbitmq_nodes
     }
 

--- a/cfy_manager/components/restservice/scripts/get_monitoring_config.py
+++ b/cfy_manager/components/restservice/scripts/get_monitoring_config.py
@@ -11,9 +11,7 @@ def _prepare_config_for_monitoring():
     cfg = {}
     rabbitmq_nodes = sm.list(models.RabbitMQBroker)
     if len(rabbitmq_nodes) > 0:
-        tmp_ca_cert_path = rabbitmq_nodes[0].write_ca_cert()
         cfg['rabbitmq'] = {
-            'ca_path': tmp_ca_cert_path,
             'cluster_members': {}
         }
         for node in rabbitmq_nodes:

--- a/cfy_manager/components/restservice/scripts/get_monitoring_config.py
+++ b/cfy_manager/components/restservice/scripts/get_monitoring_config.py
@@ -8,24 +8,16 @@ from manager_rest.flask_utils import setup_flask_app
 
 def _prepare_config_for_monitoring():
     sm = get_storage_manager()
-    cfg = {}
-    rabbitmq_nodes = sm.list(models.RabbitMQBroker)
-    if len(rabbitmq_nodes) > 0:
-        cfg['rabbitmq'] = {
-            'cluster_members': {}
-        }
-        for node in rabbitmq_nodes:
-            cfg['rabbitmq']['cluster_members'][node.name] = {
-                'networks': {'default': node.private_ip}
-            }
-    postgresql_server_nodes = sm.list(models.DBNodes)
-    if len(postgresql_server_nodes) > 0:
-        cfg['postgresql_server'] = {'cluster': {'nodes': {}}}
-        for node in postgresql_server_nodes:
-            cfg['postgresql_server']['cluster']['nodes'][node.name] = {
-                'ip': node.private_ip
-            }
-    return cfg
+    rabbitmq_nodes = {
+        node.name: node.private_ip for node in sm.list(models.RabbitMQBroker)
+    }
+    db_nodes = {
+        node.name: node.private_ip for node in sm.list(models.DBNodes)
+    }
+    return {
+        'rabbitmq_nodes': rabbitmq_nodes,
+        'db_nodes': db_nodes
+    }
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Overwriting the config is no bueno.
Make a function that returns the required data right there,
instead of tunneling it through the global config.

See each commit.