### PR TITLE
get_monitoring_config.py: don't break on the DB being down

### DIFF
--- a/cfy_manager/components/restservice/scripts/get_monitoring_config.py
+++ b/cfy_manager/components/restservice/scripts/get_monitoring_config.py
@@ -1,6 +1,8 @@
 from __future__ import print_function
 import json
 
+import sqlalchemy.exc
+
 from manager_rest import config
 from manager_rest.storage import db, models, get_storage_manager  # NOQA
 from manager_rest.flask_utils import setup_flask_app
@@ -8,12 +10,18 @@ from manager_rest.flask_utils import setup_flask_app
 
 def _prepare_config_for_monitoring():
     sm = get_storage_manager()
-    rabbitmq_nodes = {
-        node.name: node.private_ip for node in sm.list(models.RabbitMQBroker)
-    }
-    db_nodes = {
-        node.name: node.private_ip for node in sm.list(models.DBNodes)
-    }
+    try:
+        rabbitmq_nodes = {
+            node.name: node.private_ip
+            for node in sm.list(models.RabbitMQBroker)
+        }
+        db_nodes = {
+            node.name: node.private_ip
+            for node in sm.list(models.DBNodes)
+        }
+    except sqlalchemy.exc.OperationalError:
+        rabbitmq_nodes = {}
+        db_nodes = {}
     return {
         'rabbitmq_nodes': rabbitmq_nodes,
         'db_nodes': db_nodes


### PR DESCRIPTION
If we cannot connect to the DB, just return empty. Then, if we
can't ask the DB what should we be monitoring, we will only
be monitoring the nodes provided in config.yaml.

This only really happens in remove, when we're removing one
service (think 3-node cluster), and then possibly we still want
to monitor some other services, that is why we update
the monitoring targets in remove.

But if we removed the db, we just can't ask it what to monitor.