### PR TITLE
cfy_manager upgrade: reconfigure prometheus

### DIFF
--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -1072,7 +1072,7 @@ def upgrade(rpm=None, verbose=False, config_file=None):
 
     _prepare_execution(verbose, config_file=config_file)
     _validate_components_prepared('restart')
-    components = _get_components()
+    upgrade_components = _get_components()
     if rpm:
         sudo(['yum', 'install', '-y', rpm],
              stdout=sys.stdout, stderr=sys.stderr)
@@ -1082,10 +1082,11 @@ def upgrade(rpm=None, verbose=False, config_file=None):
     sudo([
         'yum', 'update', '-y', '--disablerepo=*', '--enablerepo=cloudify'
     ] + packages_to_update, stdout=sys.stdout, stderr=sys.stderr)
-    for component in components:
+    for component in upgrade_components:
         component.stop()
+    components.Prometheus().configure()
     service.reread()
-    for component in components:
+    for component in upgrade_components:
         component.start()
 
 


### PR DESCRIPTION
prometheus config changed a lot between 5.1.0 and 5.1.1,
so upgrade must reconfigure it, otherwise we just get "Fail"
outputs in status