### PR TITLE
RD-841 Add supports to add networks command when ca provided by user …

### DIFF
--- a/cfy_manager/constants.py
+++ b/cfy_manager/constants.py
@@ -145,3 +145,10 @@ NEW_PROMETHEUS_KEY_FILE_PATH = (NEW_CERTS_TMP_DIR_PATH +
                                 'new_prometheus_key.pem')
 NEW_PROMETHEUS_CA_CERT_FILE_PATH = (NEW_CERTS_TMP_DIR_PATH +
                                     'new_prometheus_ca_cert.pem')
+
+CONFIG_FILE_HELP_MSG = (
+    'Specify a configuration file to be used. File path is relative to the '
+    '{0} (meaning only files in this location are considered valid). If '
+    'more than one file is provided, these are merged in order from left '
+    'to right.'.format(CLOUDIFY_HOME_DIR)
+)

--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -47,7 +47,7 @@ from .constants import (
     VERBOSE_HELP_MSG,
     SUPERVISORD_CONFIG_DIR,
     NEW_CERTS_TMP_DIR_PATH,
-    CLOUDIFY_HOME_DIR,
+    CONFIG_FILE_HELP_MSG,
     INITIAL_INSTALL_DIR,
     INITIAL_CONFIGURE_DIR,
     INSTALLED_COMPONENTS,
@@ -159,12 +159,6 @@ VALIDATE_HELP_MSG = (
 )
 INPUT_PATH_MSG = (
     "The replace-certificates yaml configuration file path."
-)
-CONFIG_FILE_HELP_MSG = (
-    'Specify a configuration file to be used. File path is relative to the '
-    '{0} (meaning only files in this location are considered valid). If '
-    'more than one file is provided, these are merged in order from left '
-    'to right.'.format(CLOUDIFY_HOME_DIR)
 )
 
 config_arg = argh.arg('-c', '--config-file', action='append', default=None,


### PR DESCRIPTION
cfy_manager support adding networks to running cloudify manager using `cfy_manager add-networks` where the current implementation of this command assume that /etc/cloudify/ssl/certificate_metadata` always exists which is not the case the user provide the CAs when install cloudify even if its AIO or 3/9 nodes cluster. The changes added to this PR includes the following:
1. Add a flag for configuration file of cloudify installation
2. Set host name if its not set inside the configuration file
3.  Validate if metadata is empty or not 