### PR TITLE
Set global contants before upgrading Prometheus

### DIFF
--- a/cfy_manager/components/globals.py
+++ b/cfy_manager/components/globals.py
@@ -116,11 +116,12 @@ def _apply_forced_settings():
         config[POSTGRESQL_CLIENT][SSL_ENABLED] = True
 
 
-def set_globals(only_install=False):
+def set_globals(only_install=False, only_constants=False):
     if only_install:
         return
-    _apply_forced_settings()
-    _set_ip_config()
-    _set_external_port_and_protocol()
+    if not only_constants:
+        _apply_forced_settings()
+        _set_ip_config()
+        _set_external_port_and_protocol()
+        _set_hostname()
     _set_constant_config()
-    _set_hostname()

--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -1086,6 +1086,7 @@ def upgrade(rpm=None, verbose=False, config_file=None):
     ] + packages_to_update, stdout=sys.stdout, stderr=sys.stderr)
     for component in upgrade_components:
         component.stop()
+    set_globals(only_constants=True)
     components.Prometheus().configure()
     service.reread()
     for component in upgrade_components:


### PR DESCRIPTION
Some of the Prometheus configuraiton files use constants.monitoring_port
which must be set before rendering them.