### PR TITLE
Fix upgrade in cluster mode

### DIFF
--- a/cfy_manager/components/globals.py
+++ b/cfy_manager/components/globals.py
@@ -116,12 +116,11 @@ def _apply_forced_settings():
         config[POSTGRESQL_CLIENT][SSL_ENABLED] = True
 
 
-def set_globals(only_install=False, only_constants=False):
+def set_globals(only_install=False):
     if only_install:
         return
-    if not only_constants:
-        _apply_forced_settings()
-        _set_ip_config()
-        _set_external_port_and_protocol()
-        _set_hostname()
+    _apply_forced_settings()
+    _set_ip_config()
+    _set_external_port_and_protocol()
     _set_constant_config()
+    _set_hostname()

--- a/cfy_manager/components/prometheus/prometheus.py
+++ b/cfy_manager/components/prometheus/prometheus.py
@@ -20,7 +20,6 @@ import re
 
 from ..base_component import BaseComponent
 from ..components_constants import (
-    CLUSTER_JOIN,
     CONFIG,
     CONSTANTS,
     ENABLE_REMOTE_CONNECTIONS,
@@ -500,8 +499,9 @@ def _update_manager_targets(private_ip, cluster_config, uninstalling):
             postgres_targets.append(db_ip + ':' + monitoring_port)
 
         # Monitor remote manager nodes
-        if config.get(CLUSTER_JOIN):
-            for manager in _get_managers_list():
+        managers_list = _get_managers_list()
+        if len(managers_list) > 1:
+            for manager in managers_list:
                 manager_targets.append(
                     manager[PRIVATE_IP] + ':' + monitoring_port)
 
@@ -569,8 +569,9 @@ def _deploy_alerts_configuration(number_of_http_probes, cluster_config,
     if uninstalling:
         logger.info('Uninstall: Prometheus "missing" alerts will be cleared.')
     else:
-        if config.get(CLUSTER_JOIN):
-            for manager in _get_managers_list():
+        managers_list = _get_managers_list()
+        if len(managers_list) > 1:
+            for manager in managers_list:
                 manager_hosts.append(manager[PRIVATE_IP])
         else:
             manager_hosts.append(config[MANAGER][PRIVATE_IP])

--- a/cfy_manager/components/prometheus/prometheus.py
+++ b/cfy_manager/components/prometheus/prometheus.py
@@ -346,7 +346,6 @@ def _get_cluster_config():
     Based on config.yaml, but with fallback to reading nodes stored
     in the db (on manager-only nodes).
     """
-    manager_nodes = []
     try:
         db_nodes = {
             name: node['ip'] for name, node in
@@ -368,12 +367,10 @@ def _get_cluster_config():
             db_nodes = cluster_cfg['db_nodes']
         if not rabbitmq_nodes:
             rabbitmq_nodes = cluster_cfg['rabbitmq_nodes']
-        manager_nodes = cluster_cfg['managers']
 
     return {
         'db_nodes': db_nodes,
         'rabbitmq_nodes': rabbitmq_nodes,
-        'managers': manager_nodes
     }
 
 
@@ -502,7 +499,7 @@ def _update_manager_targets(private_ip, cluster_config, uninstalling):
             postgres_targets.append(db_ip + ':' + monitoring_port)
 
         # Monitor remote manager nodes
-        if len(cluster_config['managers']) > 1:
+        if common.is_manager_service_only_installed():
             for manager in _get_managers_list():
                 manager_targets.append(
                     manager[PRIVATE_IP] + ':' + monitoring_port)
@@ -571,7 +568,7 @@ def _deploy_alerts_configuration(number_of_http_probes, cluster_config,
     if uninstalling:
         logger.info('Uninstall: Prometheus "missing" alerts will be cleared.')
     else:
-        if len(cluster_config['managers']) > 1:
+        if common.is_manager_service_only_installed():
             for manager in _get_managers_list():
                 manager_hosts.append(manager[PRIVATE_IP])
         else:

--- a/cfy_manager/components/prometheus/prometheus.py
+++ b/cfy_manager/components/prometheus/prometheus.py
@@ -346,6 +346,7 @@ def _get_cluster_config():
     Based on config.yaml, but with fallback to reading nodes stored
     in the db (on manager-only nodes).
     """
+    manager_nodes = []
     try:
         db_nodes = {
             name: node['ip'] for name, node in
@@ -367,10 +368,12 @@ def _get_cluster_config():
             db_nodes = cluster_cfg['db_nodes']
         if not rabbitmq_nodes:
             rabbitmq_nodes = cluster_cfg['rabbitmq_nodes']
+        manager_nodes = cluster_cfg['managers']
 
     return {
         'db_nodes': db_nodes,
-        'rabbitmq_nodes': rabbitmq_nodes
+        'rabbitmq_nodes': rabbitmq_nodes,
+        'managers': manager_nodes
     }
 
 
@@ -499,9 +502,8 @@ def _update_manager_targets(private_ip, cluster_config, uninstalling):
             postgres_targets.append(db_ip + ':' + monitoring_port)
 
         # Monitor remote manager nodes
-        managers_list = _get_managers_list()
-        if len(managers_list) > 1:
-            for manager in managers_list:
+        if len(cluster_config['managers']) > 1:
+            for manager in _get_managers_list():
                 manager_targets.append(
                     manager[PRIVATE_IP] + ':' + monitoring_port)
 
@@ -569,9 +571,8 @@ def _deploy_alerts_configuration(number_of_http_probes, cluster_config,
     if uninstalling:
         logger.info('Uninstall: Prometheus "missing" alerts will be cleared.')
     else:
-        managers_list = _get_managers_list()
-        if len(managers_list) > 1:
-            for manager in managers_list:
+        if len(cluster_config['managers']) > 1:
+            for manager in _get_managers_list():
                 manager_hosts.append(manager[PRIVATE_IP])
         else:
             manager_hosts.append(config[MANAGER][PRIVATE_IP])

--- a/cfy_manager/components/restservice/scripts/get_monitoring_config.py
+++ b/cfy_manager/components/restservice/scripts/get_monitoring_config.py
@@ -14,12 +14,9 @@ def _prepare_config_for_monitoring():
     db_nodes = {
         node.name: node.private_ip for node in sm.list(models.DBNodes)
     }
-    managers = [node.private_ip for node in sm.list(models.Manager)]
-
     return {
         'rabbitmq_nodes': rabbitmq_nodes,
-        'db_nodes': db_nodes,
-        'managers': managers
+        'db_nodes': db_nodes
     }
 
 

--- a/cfy_manager/components/restservice/scripts/get_monitoring_config.py
+++ b/cfy_manager/components/restservice/scripts/get_monitoring_config.py
@@ -14,9 +14,12 @@ def _prepare_config_for_monitoring():
     db_nodes = {
         node.name: node.private_ip for node in sm.list(models.DBNodes)
     }
+    managers = [node.private_ip for node in sm.list(models.Manager)]
+
     return {
         'rabbitmq_nodes': rabbitmq_nodes,
-        'db_nodes': db_nodes
+        'db_nodes': db_nodes,
+        'managers': managers
     }
 
 

--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -1087,7 +1087,7 @@ def upgrade(rpm=None, verbose=False, config_file=None):
     for component in upgrade_components:
         component.stop()
     set_globals()
-    components.Prometheus().configure()
+    components.Prometheus().configure(upgrade=True)
     service.reread()
     for component in upgrade_components:
         component.start()

--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -1086,7 +1086,7 @@ def upgrade(rpm=None, verbose=False, config_file=None):
     ] + packages_to_update, stdout=sys.stdout, stderr=sys.stderr)
     for component in upgrade_components:
         component.stop()
-    set_globals(only_constants=True)
+    set_globals()
     components.Prometheus().configure()
     service.reread()
     for component in upgrade_components:


### PR DESCRIPTION
Currently, when running `cfy_manager upgrade` on a cluster, it finishes with an unhealthy cluster status. This happens because of two reasons: 
1. On a 3 nodes cluster, the `postgres_exporter.service` configuration is wrong - instead of 

`Environment="DATA_SOURCE_NAME=postgresql://cloudify_db_monitoring:c10udify_db_monitoring@localhost:5432/postgres?sslmode=disable"`, 
there should be  
`Environment="DATA_SOURCE_NAME=postgresql://cloudify_db_monitoring:c10udify_db_monitoring@172.12.0.16:5432/postgres?sslmode=verify-full&sslrootcert=/var/lib/patroni/ca.crt"`.

This is fixed by setting `POSTGRESQL_SERVER[ENABLE_REMOTE_CONNECTIONS]` to `True` in [`_apply_forced_settings`](https://github.com/cloudify-cosmo/cloudify-manager-install/blob/635cba4726258d24c5f603f2261273e5de385015/cfy_manager/components/globals.py#L115) under `set_globals()`. This parameter will be used in [this function](https://github.com/cloudify-cosmo/cloudify-manager-install/blob/ecad6bcb2e1d67b669ed0fadf6d8c7a8d27fb729/cfy_manager/components/prometheus/prometheus.py#L302) that determines the postgresql IP address.
Disclaimer: I didn't exclude any function under `set_globals()` as I thought it should behave the same way as in other functions (install, configure, etc.)

2. Both on a 3 nodes cluster and a 9 nodes cluster, `CLUSTER_JOIN` would be `False` since the upgrade process doesn't go through the `restservice` component that configures it. To solve this, I added a flag that specifies if the Promethues configuration is done as a part of an upgrade or not. This might not be the most elegant solution, but I didn't find a different solution that works (the number of different commits proves I tried (a lot)). 