### PR TITLE
RD-871 Include openssh-clients in docker image

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -11,7 +11,8 @@ RUN useradd -ms /bin/bash -g $gid --home-dir /etc/cloudify -u $uid cfyuser
 RUN yum install -y openssl-1.0.2k libselinux-utils \
     logrotate python-setuptools python-backports \
     python-backports-ssl_match_hostname which cronie \
-    systemd-sysv initscripts tcp_wrappers-libs sudo
+    systemd-sysv initscripts tcp_wrappers-libs sudo \
+    openssh-clients
 
 EXPOSE 80 443 5672 53333
 COPY $config /tmp/config.yaml


### PR DESCRIPTION
It's needed for some of our getting started examples.