### PR TITLE
Run components' upgrade functions on upgrade (#1036)

### DIFF
--- a/cfy_manager/components/base_component/base_component.py
+++ b/cfy_manager/components/base_component/base_component.py
@@ -51,6 +51,9 @@ class BaseComponent(object):
     def remove(self):
         pass
 
+    def upgrade(self):
+        pass
+
     def verify_started(self):
         pass
 

--- a/cfy_manager/components/composer/composer.py
+++ b/cfy_manager/components/composer/composer.py
@@ -188,3 +188,8 @@ class Composer(BaseComponent):
         logger.notice('Removing Composer data....')
         common.sudo(['rm', '-rf', '/opt/cloudify-composer'])
         logger.notice('Cloudify Composer successfully removed')
+
+    def upgrade(self):
+        logger.notice('Upgrading Cloudify Composer...')
+        self._run_db_migrate()
+        logger.notice('Cloudify Composer successfully upgraded')

--- a/cfy_manager/components/prometheus/prometheus.py
+++ b/cfy_manager/components/prometheus/prometheus.py
@@ -198,6 +198,9 @@ class Prometheus(BaseComponent):
         logger.notice('Prometheus successfully configured')
         self.start()
 
+    def upgrade(self):
+        self.configure(upgrade=True)
+
     def join_cluster(self):  # , restore_users_on_fail=False):
         logger.info('Would be joining cluster.')
 

--- a/cfy_manager/components/stage/stage.py
+++ b/cfy_manager/components/stage/stage.py
@@ -217,3 +217,8 @@ class Stage(BaseComponent):
         logger.notice('Removing Stage data....')
         common.sudo(['rm', '-rf', '/opt/cloudify-stage'])
         logger.notice('Stage successfully removed')
+
+    def upgrade(self):
+        logger.notice('Upgrading Cloudify Stage...')
+        self._run_db_migrate()
+        logger.notice('Cloudify Stage successfully upgraded')

--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -1084,12 +1084,12 @@ def upgrade(rpm=None, verbose=False, config_file=None):
     sudo([
         'yum', 'update', '-y', '--disablerepo=*', '--enablerepo=cloudify'
     ] + packages_to_update, stdout=sys.stdout, stderr=sys.stderr)
-    for component in upgrade_components:
+    for component in reversed(upgrade_components):
         component.stop()
     set_globals()
-    components.Prometheus().configure(upgrade=True)
     service.reread()
     for component in upgrade_components:
+        component.upgrade()
         component.start()
 
 


### PR DESCRIPTION
* Re-configure Stage component upon upgrade

* Re-configure Composer component upon upgrade

* Re-configure UI before stopping DB

During the upgrade procedure re-run UI components configuration when
database service is still running.  This is because database service is
required for the configure() functions of Stage and Composer components.

* Add extra function for upgrading components

* Prometheus().upgrade() implementation

* Stop the components in revesed order

It might be a good idea to stop the services in reverse order from how
they are setup/started.  Mainly due to their dependencies (on db service
mostly).