### PR TITLE
RD-1321 update-stored-manager: cope with clustered managers

### DIFF
--- a/cfy_manager/components/restservice/scripts/update_stored_manager.py
+++ b/cfy_manager/components/restservice/scripts/update_stored_manager.py
@@ -52,11 +52,11 @@ def main(new_manager):
     broker = sm.get(models.RabbitMQBroker, None, filters={
         'name': hostname,
         'host': manager.private_ip
-    })
+    }, fail_silently=True)
     db_node = sm.get(models.DBNodes, None, filters={
         'name': hostname,
         'host': manager.private_ip
-    })
+    }, fail_silently=True)
     for attr in ['private_ip', 'public_ip', 'networks',
                  'monitoring_username', 'monitoring_password']:
         setattr(manager, attr, new_manager[attr])


### PR DESCRIPTION
DB and broker might not be there, because they can have different
hostnames than the manager. Which is obviously the case in a
cluster.
The code already has `if broker` etc, we just need the .get
to return None rather than throw.