### PR TITLE
RD-1381 Add stopasgroup option to the rest service to stop all child …

### DIFF
--- a/cfy_manager/components/restservice/config/supervisord/cloudify-restservice.conf
+++ b/cfy_manager/components/restservice/config/supervisord/cloudify-restservice.conf
@@ -1,6 +1,7 @@
 [program:cloudify-restservice]
 user=root
 group=root
+stopasgroup=true
 command=/etc/cloudify/restservice-wrapper-script.sh {{ restservice.gunicorn.worker_count }} {{ restservice.gunicorn.max_requests }} {{ restservice.port }}
 environment=
     MANAGER_REST_CONFIG_PATH="{{ restservice.home_dir }}/cloudify-rest.conf",


### PR DESCRIPTION
This PR is added in order to force stop all the processes get spawned when running the gunicorn processes where sometimes there are some processes keep running after running `cfy_manager stop` command and it could also happened when stopping the services directly using `sudo supervisorctl stop cloudify-restservice`. The solution is to add the `stopasgroup=true` so that the supervisord can stop all of them in one shot

```
[cloud-user@cloudify-3 ~]$ ps -ef | grep "python"
root      1004     1  0 03:29 ?        00:00:00 /usr/bin/python2 -Es /usr/sbin/tuned -l -P
root      2165     1  1 03:33 ?        00:00:43 /opt/cloudify/cfy_manager/bin/python3 /usr/bin/supervisord -n -c /etc/supervisord.conf
cfyuser   7227     1 45 03:45 ?        00:19:56 /opt/manager/env/bin/python3 /opt/manager/env/bin/gunicorn -u cfyuser -g cfyuser --pid /run/cloudify-restservice/pid --chdir / --workers 5 --max-requests 1000 --bind 127.0.0.1:8100 --timeout 300 manager_rest.wsgi:app --log-file /var/log/cloudify/rest/gunicorn.log --access-logfile /var/log/cloudify/rest/gunicorn-access.log
cfyuser   7228     1 44 03:45 ?        00:19:49 /opt/manager/env/bin/python3 /opt/manager/env/bin/gunicorn -u cfyuser -g cfyuser --pid /run/cloudify-restservice/pid --chdir / --workers 5 --max-requests 1000 --bind 127.0.0.1:8100 --timeout 300 manager_rest.wsgi:app --log-file /var/log/cloudify/rest/gunicorn.log --access-logfile /var/log/cloudify/rest/gunicorn-access.log
cfyuser   7229     1 44 03:45 ?        00:19:50 /opt/manager/env/bin/python3 /opt/manager/env/bin/gunicorn -u cfyuser -g cfyuser --pid /run/cloudify-restservice/pid --chdir / --workers 5 --max-requests 1000 --bind 127.0.0.1:8100 --timeout 300 manager_rest.wsgi:app --log-file /var/log/cloudify/rest/gunicorn.log --access-logfile /var/log/cloudify/rest/gunicorn-access.log
cfyuser   7231     1 45 03:45 ?        00:20:02 /opt/manager/env/bin/python3 /opt/manager/env/bin/gunicorn -u cfyuser -g cfyuser --pid /run/cloudify-restservice/pid --chdir / --workers 5 --max-requests 1000 --bind 127.0.0.1:8100 --timeout 300 manager_rest.wsgi:app --log-file /var/log/cloudify/rest/gunicorn.log --access-logfile /var/log/cloudify/rest/gunicorn-access.log 
```
  