### PR TITLE
RD-1222 Add permissions for Deployments View widget

### DIFF
--- a/cfy_manager/components/restservice/config/authorization.conf
+++ b/cfy_manager/components/restservice/config/authorization.conf
@@ -866,6 +866,12 @@ permissions:
     - user
     - operations
     - viewer
+  widget_deploymentsView:
+    - sys_admin
+    - manager
+    - user
+    - operations
+    - viewer
   widget_deploymentWizardButtons:
     - sys_admin
     - manager


### PR DESCRIPTION
This PR adds permissions for the new Deployments View widget

See [RD-1222](https://cloudifysource.atlassian.net/browse/RD-1222)

The permissions are the same as for the regular deployments widget.