### PR TITLE
CYBL-1097 Use public ip address when creating connecting cli using ex…

### DIFF
--- a/cfy_manager/components/cli/cli.py
+++ b/cfy_manager/components/cli/cli.py
@@ -57,7 +57,7 @@ class Cli(BaseComponent):
 
         manager = config[MANAGER]['cli_local_profile_host_name']
         if not manager:
-            manager = config[MANAGER]['private_ip']
+            manager = config[MANAGER]['public_ip']
 
         use_cmd = ['profiles', 'use', manager,
                    '-u', username, '-p', password,


### PR DESCRIPTION
There could be a case that the provided external certificate does not include private_ip or localhost especially when using FQDNs instead of IPs in certificates. This will cause setup the cli profile during cfy_manager install/configure failed since the the external certificate does not include a match for localhost/private_ip. One way to avoid that is configure profile to use public_ip address instead of private

