### PR TITLE
RD-1858 Allow `cfy_manager configure` to change the password

### DIFF
--- a/cfy_manager/components/restservice/db.py
+++ b/cfy_manager/components/restservice/db.py
@@ -288,7 +288,10 @@ def insert_manager(configs):
 
 def update_stored_manager(configs=None):
     logger.notice('Updating stored manager...')
-    args = {'manager': _get_manager()}
+    args = {
+        'manager': _get_manager(),
+        'admin_password': config[MANAGER][SECURITY][ADMIN_PASSWORD],
+    }
 
     run_script('update_stored_manager.py', args, configs=configs)
     logger.notice('AMQP resources successfully created')

--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -109,8 +109,6 @@ CLEAN_DB_HELP_MSG = (
 )
 ADMIN_PASSWORD_HELP_MSG = (
     'The password of the Cloudify Manager system administrator. '
-    'Can only be used on the first install of the manager, or when using '
-    'the --clean-db flag'
 )
 ONLY_INSTALL_HELP_MSG = (
     'Whether to only perform the install, and not configuration. '
@@ -515,14 +513,7 @@ def _populate_and_validate_config_values(private_ip, public_ip,
     if public_ip:
         manager_config[PUBLIC_IP] = public_ip
     if admin_password:
-        if config[CLEAN_DB] or not _are_components_configured():
-            manager_config[SECURITY][ADMIN_PASSWORD] = admin_password
-        else:
-            raise BootstrapError(
-                'The --admin-password argument can only be used in '
-                'conjunction with the --clean-db flag or on a first '
-                'install.'
-            )
+        manager_config[SECURITY][ADMIN_PASSWORD] = admin_password
 
 
 def _prepare_execution(verbose=False,

--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -1244,7 +1244,8 @@ def image_starter(verbose=False, config_file=None):
     if not config[MANAGER].get(PUBLIC_IP):
         # if public ip is not given, default it to the same as private
         command += ['--public-ip', private_ip]
-    if not config[MANAGER].get(SECURITY, {}).get(ADMIN_PASSWORD):
+    if not config[MANAGER].get(SECURITY, {}).get(ADMIN_PASSWORD) \
+            and not _are_components_configured():
         command += ['--admin-password', 'admin']
     os.execv(sys.executable, command)
 


### PR DESCRIPTION
We have the technology! No need for clean-db!

This way, the `configure` that runs after manager/container restarts, will
be able to
1. run without touching the password if not provided,
2. change the password if the config changed.

And anyway, changing the password in the config is a thing that the user
can do, so it would be good if we handled it properly, as opposed to just
telling the user "sorry no can do, you have to drop your db".