### PR TITLE
RD-1867 CLI: use and update a single profile

### DIFF
--- a/cfy_manager/components/cli/cli.py
+++ b/cfy_manager/components/cli/cli.py
@@ -98,14 +98,6 @@ class Cli(BaseComponent):
         logger.notice('Cloudify CLI successfully configured')
         self.start()
 
-    def _should_recreate_profile(self):
-        """Should the CLI profile be recreated, ie. removed first?
-
-        If something for the `use` command changed, eg. the admin password,
-        then drop the old profile before attempting to `use` again.
-        """
-        return bool(config[MANAGER][SECURITY]['admin_password'])
-
     def _remove_profile(self, profile, use_sudo=False, silent=False):
         proc = common.cfy('profiles', 'delete', profile,
                           ignore_failures=True, sudo=use_sudo)

--- a/cfy_manager/components/cli/cli.py
+++ b/cfy_manager/components/cli/cli.py
@@ -74,8 +74,11 @@ class Cli(BaseComponent):
 
         use_cmd = ['profiles', 'use', PROFILE_NAME,
                    '--skip-credentials-validation']
-        set_cmd = ['profiles', 'set', '-m', manager,
-                   '-u', username, '-p', password, '-t', 'default_tenant']
+        set_cmd = ['profiles', 'set', '-m', manager, '-t', 'default_tenant']
+        if username:
+            set_cmd += ['-u', username]
+        if password:
+            set_cmd += ['-p', password]
         if config[MANAGER][SECURITY]['ssl_enabled']:
             set_cmd += ['-c', cert_path]
         if config['nginx']['port']:

--- a/cfy_manager/components/cli/cli.py
+++ b/cfy_manager/components/cli/cli.py
@@ -96,7 +96,6 @@ class Cli(BaseComponent):
             self._set_colors(is_root=True)
 
         logger.notice('Cloudify CLI successfully configured')
-        self.start()
 
     def _remove_profile(self, profile, use_sudo=False, silent=False):
         proc = common.cfy('profiles', 'delete', profile,

--- a/cfy_manager/components/cli/cli.py
+++ b/cfy_manager/components/cli/cli.py
@@ -15,8 +15,9 @@
 
 import errno
 import logging
-from os.path import join, exists, expanduser
+from contextlib import contextmanager
 from getpass import getuser
+from os.path import join, exists, expanduser
 
 from ..components_constants import SECURITY, SSL_INPUTS
 from ..base_component import BaseComponent
@@ -31,6 +32,17 @@ from ...constants import (EXTERNAL_CERT_PATH,
 
 logger = get_logger(CLI)
 PROFILE_NAME = 'manager-local'
+
+
+@contextmanager
+def _hide_logs():
+    """Increase the logging level, so that the password isn't in the logfile"""
+    current_level = get_file_handlers_level()
+    set_file_handlers_level(logging.ERROR)
+    try:
+        yield
+    finally:
+        set_file_handlers_level(current_level)
 
 
 class Cli(BaseComponent):
@@ -60,6 +72,8 @@ class Cli(BaseComponent):
         if not manager:
             manager = config[MANAGER]['public_ip']
 
+        use_cmd = ['profiles', 'use', PROFILE_NAME,
+                   '--skip-credentials-validation']
         set_cmd = ['profiles', 'set', '-m', manager,
                    '-u', username, '-p', password, '-t', 'default_tenant']
         if config[MANAGER][SECURITY]['ssl_enabled']:
@@ -68,26 +82,19 @@ class Cli(BaseComponent):
             set_cmd += ['--rest-port', '{0}'.format(config['nginx']['port'])]
 
         logger.info('Setting CLI for the current user (%s)...', current_user)
-        # we don't want the commands with the password to be printed
-        # to log file
-        current_level = get_file_handlers_level()
-        set_file_handlers_level(logging.ERROR)
-        common.cfy('profiles', 'use', PROFILE_NAME,
-                   '--skip-credentials-validation')
-        common.cfy(*set_cmd)
-        set_file_handlers_level(current_level)
+
+        with _hide_logs():
+            common.cfy(*use_cmd)
+            common.cfy(*set_cmd)
         self._set_colors(is_root=False)
 
         if current_user != 'root':
             logger.info('Setting CLI for the root user...')
-            set_file_handlers_level(logging.ERROR)
-            common.cfy('profiles', 'use', PROFILE_NAME,
-                       '--skip-credentials-validation',
-                       sudo=True)
-            common.cfy(*set_cmd, sudo=True)
-            set_file_handlers_level(current_level)
+            with _hide_logs():
+                common.cfy(*use_cmd, sudo=True)
+                common.cfy(*set_cmd, sudo=True)
             self._set_colors(is_root=True)
-        set_file_handlers_level(current_level)
+
         logger.notice('Cloudify CLI successfully configured')
         self.start()
 

--- a/cfy_manager/components/cli/cli.py
+++ b/cfy_manager/components/cli/cli.py
@@ -80,7 +80,9 @@ class Cli(BaseComponent):
         if password:
             set_cmd += ['-p', password]
         if config[MANAGER][SECURITY]['ssl_enabled']:
-            set_cmd += ['-c', cert_path]
+            set_cmd += ['-c', cert_path, '--ssl', 'on']
+        else:
+            set_cmd += ['--ssl', 'off']
         if config['nginx']['port']:
             set_cmd += ['--rest-port', '{0}'.format(config['nginx']['port'])]
 

--- a/cfy_manager/utils/common.py
+++ b/cfy_manager/utils/common.py
@@ -101,7 +101,12 @@ def cfy(*command, **kwargs):
     # click on py3.6 absolutely requires some locale to be set
     env = {'LC_ALL': 'en_US.UTF-8'}
     base = ['sudo', 'cfy'] if kwargs.pop('sudo', False) else ['cfy']
-    return run(base + list(command), env=env, **kwargs)
+    try:
+        return run(base + list(command), env=env, **kwargs)
+    except ProcessExecutionError as e:
+        logger.error('CLI call failed, stdout: %s, stderr: %s',
+                     e.aggr_stdout, e.aggr_stderr)
+        raise
 
 
 def mkdir(folder, use_sudo=True):


### PR DESCRIPTION
Instead of always `cfy prof use`, make a single profile with a constant name,
and `cfy prof set` it with the changed values.

Also see the jira for additional details, and see the commit messages as well.