### PR TITLE
RD-1846 - added permissions for sys_admin to has access to Getting Started Model

### DIFF
--- a/cfy_manager/components/restservice/config/authorization.conf
+++ b/cfy_manager/components/restservice/config/authorization.conf
@@ -68,7 +68,7 @@ permissions:
 # The roles here refer to both system-roles and tenant-roles (for the
 # relevant tenant only).
 #############################################################################
-  getting_started_modal
+  getting_started
     - sys_admin
 
   agent_list:

--- a/cfy_manager/components/restservice/config/authorization.conf
+++ b/cfy_manager/components/restservice/config/authorization.conf
@@ -68,7 +68,7 @@ permissions:
 # The roles here refer to both system-roles and tenant-roles (for the
 # relevant tenant only).
 #############################################################################
-  getting_started
+  getting_started:
     - sys_admin
 
   agent_list:

--- a/cfy_manager/components/restservice/config/authorization.conf
+++ b/cfy_manager/components/restservice/config/authorization.conf
@@ -68,6 +68,9 @@ permissions:
 # The roles here refer to both system-roles and tenant-roles (for the
 # relevant tenant only).
 #############################################################################
+  getting_started_modal
+    - sys_admin
+
   agent_list:
     - sys_admin
     - manager


### PR DESCRIPTION
It is necessary to set permission (RD-1846) for who is able to see Getting Started Model (developed as RD-1442).

This PR adds `sys_admin` role in the `authorization.conf` file for Getting Started Model.

Task: https://cloudifysource.atlassian.net/browse/RD-1846