### PR TITLE
RD-1535 Declare the execgroup-cancel permission

### DIFF
--- a/cfy_manager/components/restservice/config/authorization.conf
+++ b/cfy_manager/components/restservice/config/authorization.conf
@@ -336,6 +336,11 @@ permissions:
     - manager
     - user
     - operations
+  execution_group_cancel:
+    - sys_admin
+    - manager
+    - user
+    - operations
 
   file_server_auth:
     - sys_admin


### PR DESCRIPTION
It's used in cloudify-cosmo/cloudify-manager#2860