### PR TITLE
use a py3.6 container for the cfy infra

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -193,10 +193,10 @@ pipeline {
                         cfy install -b ec2-manager-install-blueprint-${env.BRANCH_NAME}-${env.BUILD_NUMBER} ec2-manager-install-blueprint.yaml
                       popd
                       cfy deployments capabilities ec2-manager-install-blueprint-${env.BRANCH_NAME}-${env.BUILD_NUMBER} --json > capabilities.json
-                      echo -e \$(cat capabilities.json | jq '.key_content.value' | tr -d '"') > ~/.ssh/ec2_ssh_key && chmod 600 ~/.ssh/ec2_ssh_key
+                      jq -r '.key_content.value' capabilities.json > ~/.ssh/ec2_ssh_key && chmod 600 ~/.ssh/ec2_ssh_key
                       sleep 160
-                      ssh-keyscan -H \$(cat capabilities.json | jq '.endpoint.value' | tr -d '"') >> ~/.ssh/known_hosts
-                      echo 'ClientAliveInterval 50' | sudo tee --append /etc/ssh/sshd_config
+                      ssh-keyscan -H \$(jq -r '.endpoint.value' capabilities.json) >> ~/.ssh/known_hosts
+                      echo 'ClientAliveInterval 50' >> /etc/ssh/sshd_config
                       """, label:'Configure and install blueprint on manager'
                     }
                   }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -185,6 +185,9 @@ pipeline {
                       pip install --upgrade pip
                       pip install cloudify==5.1.2
 
+                      apt-get update
+                      apt-get install -y jq
+
                       cfy profile use ${env.MANAGER_IP} -u ${env.MANAGER_USERNAME} -p ${env.MANAGER_PASSWORD} -t ${env.MANAGER_TENANT} --ssl
                       pushd 'bp'
                         cfy install -b ec2-manager-install-blueprint-${env.BRANCH_NAME}-${env.BUILD_NUMBER} ec2-manager-install-blueprint.yaml

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
         stage ('py3_compat'){
           steps{
             sh script: "mkdir -p ${env.WORKSPACE}/py3_compat && cp -rf ${env.WORKSPACE}/${env.PROJECT}/. ${env.WORKSPACE}/py3_compat", label: "copying repo to seperate workspace"
-            container('py27'){
+            container('py36'){
               dir("${env.WORKSPACE}/py3_compat"){
                 py3Compat()
               }
@@ -174,21 +174,17 @@ pipeline {
             script {
               buildState = 'FAILURE'
               catchError(message: 'Failure on: manager-install EC2 Creation', buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                container('py27') {
+                container('py36') {
                   echo 'Setup Github SSH key'
                   setupGithubSSHKey()
                   dir("${env.WORKSPACE}/${env.PROJECT}/jenkins") {
                     withVault([configuration: configuration, vaultSecrets: secrets]){
                       sh script:"""#!/bin/bash
-                      apt-get update
-                      python -m ensurepip --upgrade
-                      python -m pip install --upgrade pip
-                      python -m pip install --upgrade virtualenv
-
-                      virtualenv .venv
+                      python -m venv .venv
                       source .venv/bin/activate
+                      pip install --upgrade pip
+                      pip install cloudify==5.1.2
 
-                      pip install cloudify==5.1.1
                       cfy profile use ${env.MANAGER_IP} -u ${env.MANAGER_USERNAME} -p ${env.MANAGER_PASSWORD} -t ${env.MANAGER_TENANT} --ssl
                       pushd 'bp'
                         cfy install -b ec2-manager-install-blueprint-${env.BRANCH_NAME}-${env.BUILD_NUMBER} ec2-manager-install-blueprint.yaml
@@ -206,7 +202,7 @@ pipeline {
                 buildState = 'SUCCESS'
               }
             }
-          }             
+          }
         }
       }
     }
@@ -218,7 +214,7 @@ pipeline {
         script {
           buildState = 'FAILURE'
           catchError(message: 'Failure on: manager-install install manager', buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-            container('py27') {
+            container('py36') {
               dir("${env.WORKSPACE}/${env.PROJECT}/jenkins") {
                 withVault([configuration: configuration, vaultSecrets: secrets]) {
                   sh script: """#!/bin/bash
@@ -250,7 +246,7 @@ pipeline {
             script{
               buildState = 'FAILURE'
               catchError(message: 'Failure on: manager-install install manager', buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                container('py27') {
+                container('py36') {
                   dir("${env.WORKSPACE}/${env.PROJECT}/jenkins") {
                     withVault([configuration: configuration, vaultSecrets: secrets]){
                       sh script: """#!/bin/bash
@@ -296,7 +292,7 @@ sudo docker exec ${env.CONTAINER_NAME} cfy_manager sanity-check
            script{
             buildState = 'FAILURE'
             catchError(message: 'Failure on: manager-install install_cluster', buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-              container('py27') {
+              container('py36') {
                 dir("${env.WORKSPACE}/${env.PROJECT}/jenkins") {
                   withVault([configuration: configuration, vaultSecrets: secrets]) {
                     sh script: """#!/bin/bash
@@ -528,7 +524,7 @@ sudo /home/centos/${env.PROJECT}/jenkins/validate_status.sh \${NODE1_NAME} \${NO
       steps{
         script{
           catchError(message: 'Failure on: Tearing down EC2 instance of manager-install ', buildResult: 'FAILURE', stageResult: 'FAILURE') {
-            container('py27') {
+            container('py36') {
               dir("${env.WORKSPACE}/${env.PROJECT}/jenkins"){
                 withVault([configuration: configuration, vaultSecrets: secrets]) {
                   echo 'Uninstall and delete blueprint from manager'

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -39,16 +39,6 @@ pipeline {
   stages{
     stage ('compatability and flake8') {
       parallel{
-        stage ('py3_compat'){
-          steps{
-            sh script: "mkdir -p ${env.WORKSPACE}/py3_compat && cp -rf ${env.WORKSPACE}/${env.PROJECT}/. ${env.WORKSPACE}/py3_compat", label: "copying repo to seperate workspace"
-            container('py36'){
-              dir("${env.WORKSPACE}/py3_compat"){
-                py3Compat()
-              }
-            }
-          }
-        }
         stage('flake8') {
           steps{
             sh script: "mkdir -p ${env.WORKSPACE}/flake8 && cp -rf ${env.WORKSPACE}/${env.PROJECT}/. ${env.WORKSPACE}/flake8", label: "copying repo to seperate workspace"

--- a/jenkins/build-pod.yaml
+++ b/jenkins/build-pod.yaml
@@ -13,8 +13,8 @@ spec:
       securityContext:
         runAsUser: 0
         privileged: true
-    - name: py27
-      image: circleci/python:2.7
+    - name: py36
+      image: python:3.6
       resources:
         requests:
           cpu: 0.6
@@ -24,7 +24,7 @@ spec:
       securityContext:
         runAsUser: 0
         privileged: true
-      env: 
+      env:
       - name: POD_IP
         valueFrom:
           fieldRef:

--- a/jenkins/build-pod.yaml
+++ b/jenkins/build-pod.yaml
@@ -3,17 +3,6 @@ kind: Pod
 spec:
   containers:
     - name: py36
-      image: circleci/python:3.6
-      resources:
-        requests:
-          cpu: 1
-      command:
-      - cat
-      tty: true
-      securityContext:
-        runAsUser: 0
-        privileged: true
-    - name: py36
       image: python:3.6
       resources:
         requests:


### PR DESCRIPTION
This is for the container that runs `cfy`.
This is because cfy 5.1.2 can't be installed on py2 just like that (anymore),
due to networkx 1.9.1 requiring `decorator>3.4.3`, which just upgraded
to 5.0.0, which isn't py2-compatible.

So it's either pin decorator here, or just switch to py3. Switching to py3
is preferred.

Also clean up some jq usage.