### PR TITLE
RD-1869 Add predefined system filters

### DIFF
--- a/cfy_manager/components/restservice/db.py
+++ b/cfy_manager/components/restservice/db.py
@@ -245,7 +245,7 @@ def _create_system_filters_info():
         ],
         'created_at': now,
         'updated_at': now,
-        'visibility': 'tenant',
+        'visibility': 'global',
         'is_system_filter': True
     }
     service_filter = {
@@ -260,7 +260,7 @@ def _create_system_filters_info():
         ],
         'created_at': now,
         'updated_at': now,
-        'visibility': 'tenant',
+        'visibility': 'global',
         'is_system_filter': True
     }
 

--- a/cfy_manager/components/restservice/db.py
+++ b/cfy_manager/components/restservice/db.py
@@ -138,7 +138,8 @@ def _create_populate_db_args_dict():
         'premium': 'premium' if is_premium_installed() else 'community',
         'rabbitmq_brokers': _create_rabbitmq_info(),
         'db_nodes': _create_db_nodes_info(),
-        'usage_collector': _create_usage_collector_info()
+        'usage_collector': _create_usage_collector_info(),
+        'system_filters': _create_system_filters_info()
     }
     rabbitmq_ca_cert_path = config['rabbitmq'].get('ca_path')
     if rabbitmq_ca_cert_path:
@@ -222,6 +223,48 @@ def _create_usage_collector_info():
         'hours_interval': cfy_uptime['interval_in_hours'],
         'days_interval': cfy_usage['interval_in_days']
     }
+
+
+def _create_system_filters_info():
+    now = common.get_formatted_timestamp()
+    environment_filter = {
+        'id': 'csys-environment-filter',
+        'value': [
+            {
+                'key': 'csys-obj-type',
+                'values': ['environment'],
+                'operator': 'any_of',
+                'type': 'label'
+            },
+            {
+                'key': 'csys-obj-parent',
+                'values': [],
+                'operator': 'is_null',
+                'type': 'label'
+            }
+        ],
+        'created_at': now,
+        'updated_at': now,
+        'visibility': 'tenant',
+        'is_system_filter': True
+    }
+    service_filter = {
+        'id': 'csys-service-filter',
+        'value': [
+            {
+                'key': 'csys-obj-type',
+                'values': ['environment'],
+                'operator': 'not_any_of',
+                'type': 'label'
+            }
+        ],
+        'created_at': now,
+        'updated_at': now,
+        'visibility': 'tenant',
+        'is_system_filter': True
+    }
+
+    return [environment_filter, service_filter]
 
 
 def _create_process_env(rest_config=None, authorization_config=None,

--- a/cfy_manager/components/restservice/scripts/create_tables_and_add_defaults.py
+++ b/cfy_manager/components/restservice/scripts/create_tables_and_add_defaults.py
@@ -28,6 +28,7 @@ from datetime import datetime
 
 from flask_migrate import upgrade
 
+from manager_rest import constants
 from manager_rest import config, version
 from manager_rest.storage import storage_utils
 from manager_rest.amqp_manager import AMQPManager
@@ -126,7 +127,11 @@ def _insert_usage_collector(usage_collector_info):
 
 def _insert_system_filters(system_filters_info):
     sm = get_storage_manager()
+    creator = sm.get(models.User, constants.BOOTSTRAP_ADMIN_ID)
+    tenant = sm.get(models.Tenant, constants.DEFAULT_TENANT_ID)
     for system_filter in system_filters_info:
+        system_filter['creator'] = creator
+        system_filter['tenant'] = tenant
         sm.put(models.DeploymentsFilter(**system_filter))
 
 

--- a/cfy_manager/components/restservice/scripts/create_tables_and_add_defaults.py
+++ b/cfy_manager/components/restservice/scripts/create_tables_and_add_defaults.py
@@ -124,6 +124,12 @@ def _insert_usage_collector(usage_collector_info):
     sm.put(models.UsageCollector(**usage_collector_info))
 
 
+def _insert_system_filters(system_filters_info):
+    sm = get_storage_manager()
+    for system_filter in system_filters_info:
+        sm.put(models.DeploymentsFilter(**system_filter))
+
+
 def _insert_manager(config):
     sm = get_storage_manager()
     ca_cert = config.get('ca_cert')
@@ -238,3 +244,5 @@ if __name__ == '__main__':
         _insert_db_nodes(script_config['db_nodes'])
     if script_config.get('usage_collector'):
         _insert_usage_collector(script_config['usage_collector'])
+    if script_config.get('system_filters'):
+        _insert_system_filters(script_config['system_filters'])


### PR DESCRIPTION
We add predefined system filters so they can be used by the UI widgets.
This is Ofer's description of them:

> system filters are going to be used as the default value for a widget. for example: we will be using the new "deployments" widget in two different pages, one will be the environments page which will use the deployments widget filtered by "environments", and the services page will use the same widget, this time using the "services" filter.
> The filters will be available in the DB and the users should not be able to delete or modify them.
> The widget settings (edit mode for the widget) will include a "filter" setting and the out-of-the-box installation of cloudify will have the system filters as the default.