### PR TITLE
RD-2084 Don't rerender Prometheus configuration on upgrade

### DIFF
--- a/cfy_manager/components/prometheus/prometheus.py
+++ b/cfy_manager/components/prometheus/prometheus.py
@@ -173,12 +173,13 @@ class Prometheus(BaseComponent):
 
     def configure(self, upgrade=False):
         logger.notice('Configuring Prometheus Service...')
-        handle_certs()
-        _create_prometheus_directories()
-        _chown_resources_dir()
-        _deploy_configuration(upgrade)
-        extra_conf = _prometheus_additional_configuration()
-        service.configure(PROMETHEUS, external_configure_params=extra_conf)
+        if not upgrade:
+            handle_certs()
+            _create_prometheus_directories()
+            _chown_resources_dir()
+            _deploy_configuration(upgrade)
+            extra_conf = _prometheus_additional_configuration()
+            service.configure(PROMETHEUS, external_configure_params=extra_conf)
         service.reload(PROMETHEUS, ignore_failure=True)
         for exporter in _prometheus_exporters():
             service.configure(


### PR DESCRIPTION
In case of an upgrade from previous installation of cloudify-manager,
let's not re-render Prometheus configuration files.

This is because an upgrade to the cloudify-manager software should not
modify the configuration of its components, rather upgrade the software
itself.

In case of a direct requirement for a change, it should be handled by
the RPM file itself.