### PR TITLE
RD-2084 Do not re-configure Prometheus at all on upgrade

### DIFF
--- a/cfy_manager/components/prometheus/prometheus.py
+++ b/cfy_manager/components/prometheus/prometheus.py
@@ -173,13 +173,12 @@ class Prometheus(BaseComponent):
 
     def configure(self, upgrade=False):
         logger.notice('Configuring Prometheus Service...')
-        if not upgrade:
-            handle_certs()
-            _create_prometheus_directories()
-            _chown_resources_dir()
-            _deploy_configuration(upgrade)
-            extra_conf = _prometheus_additional_configuration()
-            service.configure(PROMETHEUS, external_configure_params=extra_conf)
+        handle_certs()
+        _create_prometheus_directories()
+        _chown_resources_dir()
+        _deploy_configuration(upgrade)
+        extra_conf = _prometheus_additional_configuration()
+        service.configure(PROMETHEUS, external_configure_params=extra_conf)
         service.reload(PROMETHEUS, ignore_failure=True)
         for exporter in _prometheus_exporters():
             service.configure(
@@ -199,7 +198,7 @@ class Prometheus(BaseComponent):
         self.start()
 
     def upgrade(self):
-        self.configure(upgrade=True)
+        self.start()
 
     def join_cluster(self):  # , restore_users_on_fail=False):
         logger.info('Would be joining cluster.')


### PR DESCRIPTION
* Do not re-configure Prometheus at all on upgrade

Prometheus' (a.k.a. monitoring service) configuration should not change
with newer releases of Cloudify.  So configuration shall be rendered
only in case of `cfy_manager configure` (and not `cfy_manager upgrade`)

* Don't call configure at all, just (re)start