### PR TITLE
RD-2084 Prometheus config upgrade

### DIFF
--- a/cfy_manager/components/prometheus/prometheus.py
+++ b/cfy_manager/components/prometheus/prometheus.py
@@ -171,12 +171,12 @@ class Prometheus(BaseComponent):
             logger.notice(
                 'Successfully removed Prometheus and exporters files')
 
-    def configure(self, upgrade=False):
+    def configure(self):
         logger.notice('Configuring Prometheus Service...')
         handle_certs()
         _create_prometheus_directories()
         _chown_resources_dir()
-        _deploy_configuration(upgrade)
+        _deploy_configuration()
         extra_conf = _prometheus_additional_configuration()
         service.configure(PROMETHEUS, external_configure_params=extra_conf)
         service.reload(PROMETHEUS, ignore_failure=True)
@@ -193,12 +193,12 @@ class Prometheus(BaseComponent):
             logger.notice(
                 'File {0} exists will update Prometheus config...'.format(
                     CLUSTER_DETAILS_PATH))
-            _deploy_configuration(upgrade)
+            _deploy_configuration()
         logger.notice('Prometheus successfully configured')
         self.start()
 
     def upgrade(self):
-        self.start()
+        _update_manager_alerts_services()
 
     def join_cluster(self):  # , restore_users_on_fail=False):
         logger.info('Would be joining cluster.')
@@ -294,9 +294,9 @@ def _chown_resources_dir():
     common.chown(CLOUDIFY_USER, CLOUDIFY_GROUP, PROMETHEUS_DATA_DIR)
 
 
-def _deploy_configuration(upgrade):
+def _deploy_configuration():
     _update_config()
-    _update_prometheus_configuration(upgrade=upgrade)
+    _update_prometheus_configuration()
     _deploy_exporters_configuration()
 
 
@@ -355,7 +355,7 @@ def _get_cluster_config():
     return {}
 
 
-def _update_prometheus_configuration(uninstalling=False, upgrade=False):
+def _update_prometheus_configuration(uninstalling=False):
     logger.notice('Updating Prometheus configuration...')
 
     if not uninstalling:
@@ -370,9 +370,9 @@ def _update_prometheus_configuration(uninstalling=False, upgrade=False):
     if common.is_installed(MANAGER_SERVICE):
         cluster_config = _get_cluster_config()
         http_probes_count = _update_manager_targets(
-            private_ip, cluster_config, uninstalling, upgrade)
+            private_ip, cluster_config, uninstalling)
         _deploy_alerts_configuration(
-            http_probes_count, cluster_config, uninstalling, upgrade)
+            http_probes_count, cluster_config, uninstalling)
 
     if common.is_installed(DATABASE_SERVICE):
         _update_local_postgres_targets(private_ip, uninstalling)
@@ -434,7 +434,7 @@ def _update_local_postgres_targets(private_ip, uninstalling):
                     local_postgres_targets, local_postgres_labels)
 
 
-def _update_manager_targets(private_ip, cluster_config, uninstalling, upgrade):
+def _update_manager_targets(private_ip, cluster_config, uninstalling):
     http_200_targets = []
     http_200_labels = {}
     http_401_targets = []
@@ -480,8 +480,7 @@ def _update_manager_targets(private_ip, cluster_config, uninstalling, upgrade):
             postgres_targets.append(db_ip + ':' + monitoring_port)
 
         # Monitor remote manager nodes
-        if (config.get(CLUSTER_JOIN) or
-                (upgrade and not common.is_all_in_one_manager())):
+        if config.get(CLUSTER_JOIN):
             for manager in cluster_config.get('manager_nodes', []):
                 manager_targets.append(
                     manager + ':' + monitoring_port)
@@ -536,7 +535,7 @@ def _deploy_targets(destination, targets, labels):
 
 
 def _deploy_alerts_configuration(number_of_http_probes, cluster_config,
-                                 uninstalling, upgrade):
+                                 uninstalling):
     render_context = {
         'number_of_http_probes': number_of_http_probes,
         'all_in_one': common.is_all_in_one_manager(),
@@ -550,8 +549,7 @@ def _deploy_alerts_configuration(number_of_http_probes, cluster_config,
     if uninstalling:
         logger.info('Uninstall: Prometheus "missing" alerts will be cleared.')
     else:
-        if (config.get(CLUSTER_JOIN) or
-                (upgrade and not common.is_all_in_one_manager())):
+        if config.get(CLUSTER_JOIN):
             for manager in cluster_config.get('manager_nodes', []):
                 manager_hosts.append(manager)
         else:
@@ -640,3 +638,14 @@ def _calculate_lookback_delta_for(scrape_interval):
         return '40s'
     scrape_seconds = int(m[2] or 0) + 0.001 * int(m[4] or 0)
     return '{0:d}s'.format(round(2.7 * scrape_seconds))
+
+
+def _update_manager_alerts_services():
+    logger.notice("Updating Prometheus' manager services alerts ...")
+    src_file_name = join(CONFIG_DIR, 'alerts', 'manager.yml')
+    dest_file_name = join(PROMETHEUS_ALERTS_DIR, 'manager.yml')
+    match_pattern = r'name=~"\([a-z\|\-_]*\)'
+
+    prometheus_conf = files.sudo_read(src_file_name)
+    new_services = re.findall(match_pattern, prometheus_conf)[0]
+    files.replace_in_file(match_pattern, new_services, dest_file_name)

--- a/cfy_manager/utils/files.py
+++ b/cfy_manager/utils/files.py
@@ -57,7 +57,7 @@ def replace_in_file(this, with_this, in_here):
     """
     logger.debug('Replacing {0} with {1} in {2}...'.format(
         this, with_this, in_here))
-    content = read(in_here)
+    content = sudo_read(in_here)
     new_content = re.sub(this, with_this, content)
     write_to_file(new_content, in_here)
 


### PR DESCRIPTION
* Get rid of upgrade parameter

Since we're not running configure() on Prometheus.upgrade(), the
parameter is unnecessary.

* Update manager services alerts while upgrading

In case a new version of Cloudify has a different set of manager's
services running, let's update it during the upgrade process.