### PR TITLE
RD-2035 Modify csys-service-filter

### DIFF
--- a/cfy_manager/components/restservice/db.py
+++ b/cfy_manager/components/restservice/db.py
@@ -253,8 +253,8 @@ def _create_system_filters_info():
         'value': [
             {
                 'key': 'csys-obj-type',
-                'values': ['environment'],
-                'operator': 'not_any_of',
+                'values': ['service'],
+                'operator': 'any_of',
                 'type': 'label'
             }
         ],


### PR DESCRIPTION
Currently, the system filter `csys-service-filter` filter rule is `csys-obj-type!=environment`. This means that if a user attaches a label to a deployment with the key `csys-obj-type` with any value different from `environment` (not necessarily `service`), it will be returned too. 

To solve this we need to change the filter rule to be `csys-obj-type=service`. 