### PR TITLE
RD-2146 Using is_not operator in services system filter

### DIFF
--- a/cfy_manager/components/restservice/db.py
+++ b/cfy_manager/components/restservice/db.py
@@ -253,8 +253,8 @@ def _create_system_filters_info():
         'value': [
             {
                 'key': 'csys-obj-type',
-                'values': ['service'],
-                'operator': 'any_of',
+                'values': ['environment'],
+                'operator': 'is_not',
                 'type': 'label'
             }
         ],


### PR DESCRIPTION
The `is_not` operator was created especially for this task. We would like the services' system filter to capture all the deployments that have a label with key `csys-obj-type` and value other than `environment`, or don't have a label with the key `csys-obj-type` at all. This is done using the `is_not` operator. 

FYI, @Gelio 