### PR TITLE
RD-2292 Use set globals when replacing certs

### DIFF
--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -1277,6 +1277,7 @@ def replace_certificates(input_path=None,
     """ Replacing the certificates on the current instance """
     setup_console_logger(verbose)
     config.load_config(config_file)
+    set_globals()
     _handle_replace_certs_config_path(input_path)
     if only_validate:
         _only_validate()


### PR DESCRIPTION
Replace certificates relies on the hostname, which does not behave as the
config.yaml comments suggest it does unless set_globals is called.