### PR TITLE
RD-2464 Refactor installation files

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -55,27 +55,26 @@ pipeline {
             }
           }
         }
-//         stage('fetch_rpms') {
-//           steps {
-//             sh script:"mkdir -p ${env.WORKSPACE}/rpms", label: "creating RPMs folder"
-//             container('python') {
-//               dir("${env.WORKSPACE}/rpms") {
-//                 withVault([configuration: configuration, vaultSecrets: secrets]) {
-//                   echo 'Install requests'
-//                   sh 'pip install requests'
-//                   sh script:"""#!/bin/bash
-//                      source ${env.WORKSPACE}/${env.PROJECT}/packaging/source_branch
-//                      chmod +x ${env.WORKSPACE}/${env.PROJECT}/jenkins/fetch_rpms
-//                      ${env.WORKSPACE}/${env.PROJECT}/jenkins/fetch_rpms -u ${env.JENKINS_USERNAME} -t ${env.JENKINS_TOKEN} -d ${env.WORKSPACE}/rpms
-//                      """, label: 'Fetch RPM artifacts stored on Jenkins'
-//                 }
-//               }
-//             }
-//           }
-//         }
-        stage('build_prometheus_rpms') {
+        stage('fetch_rpms') {
           steps {
             sh script:"mkdir -p ${env.WORKSPACE}/rpms", label: "creating RPMs folder"
+            container('python') {
+              dir("${env.WORKSPACE}/rpms") {
+                withVault([configuration: configuration, vaultSecrets: secrets]) {
+                  echo 'Install requests'
+                  sh 'pip install requests'
+                  sh script:"""#!/bin/bash
+                     source ${env.WORKSPACE}/${env.PROJECT}/packaging/source_branch
+                     chmod +x ${env.WORKSPACE}/${env.PROJECT}/jenkins/fetch_rpms
+                     ${env.WORKSPACE}/${env.PROJECT}/jenkins/fetch_rpms -u ${env.JENKINS_USERNAME} -t ${env.JENKINS_TOKEN} -d ${env.WORKSPACE}/rpms
+                     """, label: 'Fetch RPM artifacts stored on Jenkins'
+                }
+              }
+            }
+          }
+        }
+        stage('build_prometheus_rpms') {
+          steps {
             sh script: "mkdir -p ${env.WORKSPACE}/prometheus && cp -rf ${env.WORKSPACE}/${env.PROJECT}/. ${env.WORKSPACE}/prometheus", label: "copying repo to seperate workspace"
             container('rpmbuild') {
               dir("${env.WORKSPACE}/prometheus") {

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -75,6 +75,7 @@ pipeline {
 //         }
         stage('build_prometheus_rpms') {
           steps {
+            sh script:"mkdir -p ${env.WORKSPACE}/rpms", label: "creating RPMs folder"
             sh script: "mkdir -p ${env.WORKSPACE}/prometheus && cp -rf ${env.WORKSPACE}/${env.PROJECT}/. ${env.WORKSPACE}/prometheus", label: "copying repo to seperate workspace"
             container('rpmbuild') {
               dir("${env.WORKSPACE}/prometheus") {

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -55,24 +55,24 @@ pipeline {
             }
           }
         }
-        stage('fetch_rpms') {
-          steps {
-            sh script:"mkdir -p ${env.WORKSPACE}/rpms", label: "creating RPMs folder"
-            container('python') {
-              dir("${env.WORKSPACE}/rpms") {
-                withVault([configuration: configuration, vaultSecrets: secrets]) {
-                  echo 'Install requests'
-                  sh 'pip install requests'
-                  sh script:"""#!/bin/bash
-                     source ${env.WORKSPACE}/${env.PROJECT}/packaging/source_branch
-                     chmod +x ${env.WORKSPACE}/${env.PROJECT}/jenkins/fetch_rpms
-                     ${env.WORKSPACE}/${env.PROJECT}/jenkins/fetch_rpms -u ${env.JENKINS_USERNAME} -t ${env.JENKINS_TOKEN} -d ${env.WORKSPACE}/rpms
-                     """, label: 'Fetch RPM artifacts stored on Jenkins'
-                }
-              }
-            }
-          }
-        }
+//         stage('fetch_rpms') {
+//           steps {
+//             sh script:"mkdir -p ${env.WORKSPACE}/rpms", label: "creating RPMs folder"
+//             container('python') {
+//               dir("${env.WORKSPACE}/rpms") {
+//                 withVault([configuration: configuration, vaultSecrets: secrets]) {
+//                   echo 'Install requests'
+//                   sh 'pip install requests'
+//                   sh script:"""#!/bin/bash
+//                      source ${env.WORKSPACE}/${env.PROJECT}/packaging/source_branch
+//                      chmod +x ${env.WORKSPACE}/${env.PROJECT}/jenkins/fetch_rpms
+//                      ${env.WORKSPACE}/${env.PROJECT}/jenkins/fetch_rpms -u ${env.JENKINS_USERNAME} -t ${env.JENKINS_TOKEN} -d ${env.WORKSPACE}/rpms
+//                      """, label: 'Fetch RPM artifacts stored on Jenkins'
+//                 }
+//               }
+//             }
+//           }
+//         }
         stage('build_prometheus_rpms') {
           steps {
             sh script: "mkdir -p ${env.WORKSPACE}/prometheus && cp -rf ${env.WORKSPACE}/${env.PROJECT}/. ${env.WORKSPACE}/prometheus", label: "copying repo to seperate workspace"


### PR DESCRIPTION
This PR fixes the removal of a single service from a manager that uses the cfy-installer image (more about it in the [JIRA](https://cloudifysource.atlassian.net/browse/RD-2464)). 

The fix includes the following:

- The packages.yaml file includes all main services as keys, and the value of each service is a list of the packages related to it. Following this PR, in case the config.yaml file includes `monitoring_service` and `enrotpy_service`, their related packages will be appended to each list of a main service (manager, database, queue). The logic behind this is that if the user installed these services (entropy and monitoring), it doesn't matter if they didn't put them in the config.yaml file they used for configuration - they are installed. 
- Simplifying the `_get_items_to_remove` function. It has the same functionality, but it's now a lot simpler. 