### PR TITLE
Generate the external certs from the internal CA only if it exists

### DIFF
--- a/cfy_manager/components/nginx/nginx.py
+++ b/cfy_manager/components/nginx/nginx.py
@@ -96,9 +96,11 @@ class Nginx(BaseComponent):
         ca_key = config[SSL_INPUTS]['external_ca_key_path']
         key_password = config[SSL_INPUTS]['external_ca_key_password']
         if not (ca_cert and ca_key):
-            ca_cert = constants.CA_CERT_PATH
-            ca_key = constants.CA_KEY_PATH
-            key_password = config[SSL_INPUTS]['ca_key_password']
+            if exists(constants.CA_CERT_PATH) and \
+                    exists(constants.CA_KEY_PATH):
+                ca_cert = constants.CA_CERT_PATH
+                ca_key = constants.CA_KEY_PATH
+                key_password = config[SSL_INPUTS]['ca_key_password']
         certificates.generate_external_ssl_cert(
             ips=[external_rest_host, internal_rest_host],
             cn=hostname,


### PR DESCRIPTION
Currently, we try to generate the external certificate from the internal CA cert and key, but don't verify they indeed exist. This PR fixes it.