### PR TITLE
RD-2522 IPv6 fix-ups

### DIFF
--- a/cfy_manager/components/postgresql_server/postgresql_server.py
+++ b/cfy_manager/components/postgresql_server/postgresql_server.py
@@ -485,10 +485,10 @@ class PostgresqlServer(BaseComponent):
         ).aggr_stdout)
 
     def _get_etcd_id(self, ip):
-        return 'etcd' + ip.replace('.', '_').replace(':', '_')
+        return 'etcd' + _ip_to_identifier(ip)
 
     def _get_patroni_id(self, address):
-        return 'pg' + address.replace('.', '_').replace(':', '_')
+        return 'pg' + _ip_to_identifier(address)
 
     def _etcd_requires_auth(self):
         logger.info('Checking whether etcd requires auth.')
@@ -716,14 +716,15 @@ class PostgresqlServer(BaseComponent):
                         members=valid_names,
                     )
                 )
-        ip_urlized = '[{0}]'.format(private_ip) if network.is_ipv6(private_ip)\
+        ip_urlized = network.ipv6_url_compat(private_ip)\
+            if network.is_ipv6(private_ip)\
             else socket.gethostbyname(private_ip)
         cluster_nodes = {k: v for k, v in
                          config[POSTGRESQL_SERVER]['cluster']['nodes'].items()}
         for k, v in cluster_nodes.items():
             if 'ip' in v:
                 v['ip'] = network.ipv6_url_compat(v['ip'])
-        etcd_name_suffix = etcd_name_suffix.replace('.', '_').replace(':', '_')
+        etcd_name_suffix = _ip_to_identifier(etcd_name_suffix)
 
         files.deploy(
             os.path.join(CONFIG_PATH, 'etcd.conf'), ETCD_CONFIG_PATH,
@@ -1014,7 +1015,7 @@ class PostgresqlServer(BaseComponent):
             ),
         ])
 
-        patroni_name = manager_ip.replace('.', '_').replace(':', '_')
+        patroni_name = _ip_to_identifier(manager_ip)
         ip_urlized = network.ipv6_url_compat(manager_ip)
         patroni_conf = {
             'scope': 'postgres',
@@ -1761,3 +1762,7 @@ class PostgresqlServer(BaseComponent):
 
     def validate_dependencies(self):
         super(PostgresqlServer, self).validate_dependencies()
+
+
+def _ip_to_identifier(ip):
+    return ip.replace('.', '_').replace(':', '_')

--- a/cfy_manager/utils/db.py
+++ b/cfy_manager/utils/db.py
@@ -234,11 +234,8 @@ def get_ui_db_dialect_options_and_url(database, certs):
             )
             for host in postgres_host
         ]
-    host_details = postgres_host.rsplit(':', 1)
-    if len(host_details) > 1 and host_details[1].isnumeric():
-        host = host_details[0]
-        port = host_details[1]
-    else:
+    host, _, port = postgres_host.rpartition(':')
+    if not port.isdigit():
         host = postgres_host
         port = '5432'
     return dialect_options, conn_string.format(

--- a/cfy_manager/utils/network.py
+++ b/cfy_manager/utils/network.py
@@ -12,7 +12,7 @@
 #  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
-
+import ipaddress
 import os
 import socket
 import base64
@@ -133,12 +133,10 @@ def check_http_response(url, **request_kwargs):
 
 def is_ipv6(addr):
     """Verifies if `addr` is a valid IPv6 address."""
-    # TODO replace socket with ipaddress once we're py3-only
     try:
-        socket.inet_pton(socket.AF_INET6, addr)
-    except socket.error:
+        return bool(ipaddress.IPv6Address(addr))
+    except ipaddress.AddressValueError:
         return False
-    return True
 
 
 def ipv6_url_compat(addr):


### PR DESCRIPTION
* Factor out `_ip_to_identifier` function.  The function makes nice
identifiers based on both IPv4, IPv6 and also hostname-based
addresses, e.g. `10.10.10.10` becomes `10_10_10_10`, `fe80::1`
becomes `fe80__1` and `example.com` becomes `example_com`.

* Use `ipv6_url_compat` instead of manually formatting IPv6 into URL.
This makes for a slightly slower code, but the code becomes less
bug-prone and maybe also readable.

* Factor out IPv6 enabled check for RabbitMQ installation

* Cleaner postgres_host partitioning into host:port

* Use `ipaddress` package to detect IPv6 address instead of using
`socket.inet_pton()`