### PR TITLE
RD-2621 Introduce `rabbitmq.is_external` config flag

### DIFF
--- a/cfy_manager/components/restservice/db.py
+++ b/cfy_manager/components/restservice/db.py
@@ -157,6 +157,7 @@ def _get_monitoring_credentials():
 def _create_rabbitmq_info():
     monitoring_credentials = _get_monitoring_credentials()
     use_hostnames = config[RABBITMQ]['use_hostnames_in_db']
+    is_external = config[RABBITMQ].get('is_external', False)
     return [
         {
             'name': name,
@@ -168,7 +169,7 @@ def _create_rabbitmq_info():
             'password': config[RABBITMQ]['password'],
             'params': None,
             'networks': broker[NETWORKS],
-            'is_external': broker.get('networks', {}).get('default') is None,
+            'is_external': is_external,
             'monitoring_username': monitoring_credentials['username'],
             'monitoring_password': monitoring_credentials['password'],
         }

--- a/config.yaml
+++ b/config.yaml
@@ -107,6 +107,10 @@ rabbitmq:
   # This should not be populated on an all-in-one manager.
   cluster_members: {}
 
+  # Set this to true if the RabbitMQ is an external service.  This will result in the RabbitMQ
+  # service not being internally-monitored by the CLoudify cluster status reporter.
+  is_external: false
+
   # Path to cert for CA that signed the broker cert.
   # Must be provided to use external brokers.
   # Will default to cert_path if installing a broker locally.


### PR DESCRIPTION
… which marks RabbitMQ service as external.