### PR TITLE
RD-2621 Drop monitoring credentials

### DIFF
--- a/cfy_manager/components/restservice/db.py
+++ b/cfy_manager/components/restservice/db.py
@@ -20,7 +20,6 @@ from ..service_names import (
     MANAGER,
     POSTGRESQL_CLIENT,
     POSTGRESQL_SERVER,
-    PROMETHEUS,
     RABBITMQ,
     RESTSERVICE,
 )
@@ -147,15 +146,7 @@ def _create_populate_db_args_dict():
     return args_dict
 
 
-def _get_monitoring_credentials():
-    return {
-        'username': config[PROMETHEUS].get('credentials', {}).get('username'),
-        'password': config[PROMETHEUS].get('credentials', {}).get('password'),
-    }
-
-
 def _create_rabbitmq_info():
-    monitoring_credentials = _get_monitoring_credentials()
     use_hostnames = config[RABBITMQ]['use_hostnames_in_db']
     return [
         {
@@ -169,23 +160,17 @@ def _create_rabbitmq_info():
             'params': None,
             'networks': broker[NETWORKS],
             'is_external': broker.get('networks', {}).get('default') is None,
-            'monitoring_username': monitoring_credentials['username'],
-            'monitoring_password': monitoring_credentials['password'],
         }
         for name, broker in config[RABBITMQ]['cluster_members'].items()
     ]
 
 
 def _create_db_nodes_info():
-    monitoring_credentials = _get_monitoring_credentials()
-
     if common.is_all_in_one_manager():
         return [{
             'name': config[MANAGER][HOSTNAME],
             'host': config[NETWORKS]['default'],
             'is_external': False,
-            'monitoring_username': monitoring_credentials['username'],
-            'monitoring_password': monitoring_credentials['password'],
         }]
 
     if common.manager_using_db_cluster():
@@ -195,8 +180,6 @@ def _create_db_nodes_info():
                 'name': name,
                 'host': db['ip'],
                 'is_external': False,
-                'monitoring_username': monitoring_credentials['username'],
-                'monitoring_password': monitoring_credentials['password'],
             }
             for name, db in db_nodes.items()
         ]
@@ -206,8 +189,6 @@ def _create_db_nodes_info():
         'name': config[POSTGRESQL_CLIENT]['host'],
         'host': config[POSTGRESQL_CLIENT]['host'],
         'is_external': True,
-        'monitoring_username': monitoring_credentials['username'],
-        'monitoring_password': monitoring_credentials['password'],
     }]
 
 
@@ -262,7 +243,6 @@ def populate_db(configs):
 
 
 def _get_manager():
-    monitoring_credentials = _get_monitoring_credentials()
     try:
         with open(constants.CA_CERT_PATH) as f:
             ca_cert = f.read()
@@ -274,8 +254,6 @@ def _get_manager():
         'private_ip': config['manager']['private_ip'],
         'networks': config[NETWORKS],
         'last_seen': common.get_formatted_timestamp(),
-        'monitoring_username': monitoring_credentials['username'],
-        'monitoring_password': monitoring_credentials['password'],
         'ca_cert': ca_cert
     }
 

--- a/cfy_manager/components/restservice/scripts/create_tables_and_add_defaults.py
+++ b/cfy_manager/components/restservice/scripts/create_tables_and_add_defaults.py
@@ -159,8 +159,6 @@ def _insert_manager(config):
         distro_release=version_data['distro_release'],
         _ca_cert_id=ca,
         last_seen=config['last_seen'],
-        monitoring_username=config['monitoring_username'],
-        monitoring_password=config['monitoring_password'],
     )
     sm.put(inst)
 

--- a/cfy_manager/components/restservice/scripts/create_tables_and_add_defaults.py
+++ b/cfy_manager/components/restservice/scripts/create_tables_and_add_defaults.py
@@ -134,7 +134,7 @@ def _insert_manager(config):
 
     if not stored_cert and not ca_cert:
         raise RuntimeError('No manager certs found, and ca_cert not given')
-    elif stored_cert and not ca_cert:
+    if stored_cert and not ca_cert:
         with open(CA_CERT_PATH, 'w') as f:
             f.write(stored_cert.value)
         subprocess.check_call(['sudo', 'chown', 'cfyuser.', CA_CERT_PATH])
@@ -188,9 +188,8 @@ def _add_provider_context(context):
 def file_path(path):
     if os.path.exists(path):
         return path
-    else:
-        raise argparse.ArgumentTypeError(
-            "The file path \"{0}\" doesn't exist.".format(path))
+    raise argparse.ArgumentTypeError(
+        "The file path \"{0}\" doesn't exist.".format(path))
 
 
 if __name__ == '__main__':

--- a/cfy_manager/components/restservice/scripts/update_stored_manager.py
+++ b/cfy_manager/components/restservice/scripts/update_stored_manager.py
@@ -66,8 +66,7 @@ def main(new_manager, admin_password):
         'name': hostname,
         'host': manager.private_ip
     }, fail_silently=True)
-    for attr in ['private_ip', 'public_ip', 'networks',
-                 'monitoring_username', 'monitoring_password']:
+    for attr in ['private_ip', 'public_ip', 'networks']:
         setattr(manager, attr, new_manager[attr])
 
     sm.update(manager)
@@ -76,14 +75,10 @@ def main(new_manager, admin_password):
             broker.management_host = manager.private_ip
         broker.host = manager.private_ip
         broker.networks = manager.networks
-        broker.monitoring_username = manager.monitoring_username
-        broker.monitoring_password = manager.monitoring_password
         sm.update(broker)
 
     if db_node:
         db_node.host = manager.private_ip
-        db_node.monitoring_username = manager.monitoring_username
-        db_node.monitoring_password = manager.monitoring_password
         sm.update(db_node)
 
     if new_manager.get('ca_cert'):


### PR DESCRIPTION
`monitoring_username` and `monitoring_password` columns for manager, db and rabbit nodes are no longer necessary.  Instead we use the same credentials across all of the the Prometheus' federated nodes.