### PR TITLE
Don't warn when using sudo to access yaml files

### DIFF
--- a/cfy_manager/config.py
+++ b/cfy_manager/config.py
@@ -114,8 +114,8 @@ class Config(CommentedMap):
                 with open(path_to_yaml) as f:
                     yaml_data = f.read()
             except PermissionError as e:
-                logger.warning('Cannot access %s, trying with sudo (%s)',
-                               path_to_yaml, e)
+                logger.debug('Cannot access %s, trying with sudo (%s)',
+                             path_to_yaml, e)
                 yaml_data = subprocess.check_output([
                     'sudo', 'cat', path_to_yaml
                 ])


### PR DESCRIPTION
It happens on pretty much every run, so it really doesn't need to be so dramatic.