### PR TITLE
RD-2756 Log X-Cloudify-Audit-*

### DIFF
--- a/cfy_manager/components/nginx/config/rest-proxy.cloudify
+++ b/cfy_manager/components/nginx/config/rest-proxy.cloudify
@@ -7,6 +7,10 @@
     proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
     proxy_set_header   X-Forwarded-Proto $scheme;
 
+    proxy_hide_header  X-Cloudify-Audit-Auth-Method;
+    proxy_hide_header  X-Cloudify-Audit-Tenant;
+    proxy_hide_header  X-Cloudify-Audit-Username;
+
     gzip on;
     gzip_types application/json;
     gzip_min_length 1000;

--- a/cfy_manager/components/restservice/scripts/restservice-wrapper-script.sh
+++ b/cfy_manager/components/restservice/scripts/restservice-wrapper-script.sh
@@ -20,4 +20,5 @@ exec /opt/manager/env/bin/gunicorn \
     --bind 127.0.0.1:$port \
     --timeout 300 manager_rest.wsgi:app \
     --log-file /var/log/cloudify/rest/gunicorn.log \
-    --access-logfile /var/log/cloudify/rest/gunicorn-access.log
+    --access-logfile /var/log/cloudify/rest/gunicorn-access.log \
+    --access-logformat '%(t)s %(h)s %({X-Cloudify-Audit-Username}o)s %({X-Cloudify-Audit-Tenant}o)s %({X-Cloudify-Audit-Auth-Method}o)s "%(r)s" %(s)s %(b)s "%(a)s" took %(D)sus'

--- a/cfy_manager/components/restservice/scripts/restservice-wrapper-script.sh
+++ b/cfy_manager/components/restservice/scripts/restservice-wrapper-script.sh
@@ -20,5 +20,5 @@ exec /opt/manager/env/bin/gunicorn \
     --bind 127.0.0.1:$port \
     --timeout 300 manager_rest.wsgi:app \
     --log-file /var/log/cloudify/rest/gunicorn.log \
-    --access-logfile /var/log/cloudify/rest/gunicorn-access.log \
+    --access-logfile /var/log/cloudify/rest/audit.log \
     --access-logformat '%(t)s %(h)s %({X-Cloudify-Audit-Username}o)s %({X-Cloudify-Audit-Tenant}o)s %({X-Cloudify-Audit-Auth-Method}o)s "%(r)s" %(s)s %(b)s "%(a)s" took %(D)sus'

--- a/cfy_manager/components/restservice/scripts/restservice-wrapper-script.sh
+++ b/cfy_manager/components/restservice/scripts/restservice-wrapper-script.sh
@@ -21,4 +21,4 @@ exec /opt/manager/env/bin/gunicorn \
     --timeout 300 manager_rest.wsgi:app \
     --log-file /var/log/cloudify/rest/gunicorn.log \
     --access-logfile /var/log/cloudify/rest/audit.log \
-    --access-logformat '%(t)s %(h)s %({X-Cloudify-Audit-Username}o)s %({X-Cloudify-Audit-Tenant}o)s %({X-Cloudify-Audit-Auth-Method}o)s "%(r)s" %(s)s %(b)s "%(a)s" took %(D)sus'
+    --access-logformat '%(t)s %(h)s %({X-Cloudify-Audit-Username}o)s %({X-Cloudify-Audit-Tenant}o)s %({X-Cloudify-Audit-Auth-Method}o)s "%(r)s" %(s)s %(b)s "%(a)s" took %(M)sms'


### PR DESCRIPTION
Add `X-Cloudify-Audit-*` response header values to gunicorn-access.log.
Make the file easier to read.