### PR TITLE
Declare the dep-update update permission

### DIFF
--- a/cfy_manager/components/restservice/config/authorization.conf
+++ b/cfy_manager/components/restservice/config/authorization.conf
@@ -232,6 +232,11 @@ permissions:
     - manager
     - user
     - operations
+  deployment_update_update:
+    - sys_admin
+    - manager
+    - user
+    - operations
 
   deployment_group_list:
     - sys_admin


### PR DESCRIPTION
A permission to update dep-up objects. They are mutable and so
non-admin users would also like to mutate them.