### PR TITLE
WDR-79 chown rabbitmq:rabbitmq /etc/rabbitmq/erl_inetrc

### DIFF
--- a/cfy_manager/components/rabbitmq/rabbitmq.py
+++ b/cfy_manager/components/rabbitmq/rabbitmq.py
@@ -88,10 +88,11 @@ class RabbitMQ(BaseComponent):
         logger.info('Deploying RabbitMQ env')
         deploy(join(CONFIG_PATH, 'rabbitmq-env.conf'), RABBITMQ_ENV_PATH,
                additional_render_context={'ipv6_enabled': ipv6_enabled})
+        common.chown('rabbitmq', 'rabbitmq', RABBITMQ_ENV_PATH)
         if ipv6_enabled:
             logger.info('Deploying Erlang inet configuration')
             deploy(join(CONFIG_PATH, 'erl_inetrc'), RABBITMQ_ERL_INETRC)
-        common.chown('rabbitmq', 'rabbitmq', RABBITMQ_ENV_PATH)
+            common.chown('rabbitmq', 'rabbitmq', RABBITMQ_ERL_INETRC)
 
     def _init_service(self):
         logger.info('Initializing RabbitMQ...')


### PR DESCRIPTION
chown because otherwise file is (sometimes) not readable producing errors:

```
inet_config: file /etc/rabbitmq/erl_inetrc not found
File operation error: eacces. Target: /etc/rabbitmq/erl_inetrc. Function: get_file. Process: kernel_sup.
```