### PR TITLE
wait-for-starter: bump timeout to 10 mins

### DIFF
--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -1196,7 +1196,7 @@ class _FileFollow(object):
 
 @argh.decorators.named('wait-for-starter')
 @config_arg
-def wait_for_starter(timeout=300, config_file=None):
+def wait_for_starter(timeout=600, config_file=None):
     config.load_config(config_file)
 
     _follow = _FileFollow('/var/log/cloudify/manager/cfy_manager.log')


### PR DESCRIPTION
Jenkins' inte-tests keep timeouting on this. 5 minutes is not enough?!
Fine, here, have 10 minutes.

We should really make this faster, but for today, I want to see the
tests run at all