### PR TITLE
RD-3257 Make supervisord etcd use same config

### DIFF
--- a/cfy_manager/components/postgresql_server/config/supervisord/etcd.conf
+++ b/cfy_manager/components/postgresql_server/config/supervisord/etcd.conf
@@ -4,23 +4,4 @@ user=etcd
 directory=/var/lib/etcd/
 stdout_syslog=true
 stderr_syslog=true
-environment=
-    HOME="/var/lib/etcd",
-    USER="etcd",
-    ETCD_LISTEN_PEER_URLS="https://{{ ip }}:2380",
-    ETCD_LISTEN_CLIENT_URLS="https://localhost:2379,https://{{ ip }}:2379",
-    ETCD_INITIAL_ADVERTISE_PEER_URLS="https://{{ manager.private_ip }}:2380",
-    ETCD_INITIAL_CLUSTER="{% for node in postgresql_server.cluster.nodes.values() -%}etcd{{ node.ip.replace('.', '_') }}=https://{{ node.ip }}:2380,{% endfor %}",
-    ETCD_ADVERTISE_CLIENT_URLS="https://{{ manager.private_ip }}:2379",
-    ETCD_INITIAL_CLUSTER_TOKEN="{{ postgresql_server.cluster.etcd.cluster_token.replace("'", '"').replace('\\', '/') }}",
-    ETCD_INITIAL_CLUSTER_STATE="new",
-    ETCD_DATA_DIR="/var/lib/etcd",
-    ETCD_PEER_CERT_FILE='/etc/etcd/etcd.crt',
-    ETCD_PEER_KEY_FILE='/etc/etcd/etcd.key',
-    ETCD_PEER_TRUSTED_CA_FILE='/etc/etcd/ca.crt',
-    ETCD_CERT_FILE='/etc/etcd/etcd.crt',
-    ETCD_KEY_FILE='/etc/etcd/etcd.key',
-    ETCD_TRUSTED_CA_FILE='/etc/etcd/ca.crt',
-    ETCD_NAME='etcd{{ manager.private_ip.replace('.', '_') }}',
-
-command=/bin/bash -c "GOMAXPROCS=$(nproc) /usr/bin/etcd --name=\"${ETCD_NAME}\" --data-dir=\"${ETCD_DATA_DIR}\" --listen-client-urls=\"${ETCD_LISTEN_CLIENT_URLS}\""
+command=/bin/bash -c "set -a; . /etc/etcd/etcd.conf; set +a; GOMAXPROCS=$(nproc) HOME="/var/lib/etcd" USER="etcd" /usr/bin/etcd --name=\"${ETCD_NAME}\" --data-dir=\"${ETCD_DATA_DIR}\" --listen-client-urls=\"${ETCD_LISTEN_CLIENT_URLS}\""


### PR DESCRIPTION
The systemd one uses this config file, and we update it in some situations,
so let's just use the same one for both service managements.