### PR TITLE
RD-3408 Manage patroni startup service

### DIFF
--- a/cfy_manager/components/postgresql_server/postgresql_server.py
+++ b/cfy_manager/components/postgresql_server/postgresql_server.py
@@ -1708,6 +1708,8 @@ class PostgresqlServer(BaseComponent):
             self._start_etcd()
             service.start('patroni')
             service.verify_alive('patroni')
+            service.start('patroni_startup_check')
+            service.verify_alive('patroni_startup_check')
         else:
             service.start(POSTGRES_SERVICE_NAME)
             service.verify_alive(POSTGRES_SERVICE_NAME)
@@ -1717,6 +1719,7 @@ class PostgresqlServer(BaseComponent):
         logger.notice('Stopping PostgreSQL Server...')
         if config[POSTGRESQL_SERVER]['cluster']['nodes']:
             service.stop('etcd')
+            service.stop('patroni_startup_check')
             service.stop('patroni')
         else:
             service.stop(POSTGRES_SERVICE_NAME)


### PR DESCRIPTION
If we don't stop it then it'll restart patroni, which makes cfy_manager stop a lie
(and breaks tests).