### PR TITLE
RD-2872 Allow admins retrieving password hashes

### DIFF
--- a/cfy_manager/components/restservice/config/authorization.conf
+++ b/cfy_manager/components/restservice/config/authorization.conf
@@ -1100,3 +1100,5 @@ permissions:
     - operations
     - viewer
     - default
+  get_password_hash:
+    - sys_admin


### PR DESCRIPTION
Note that these are useless without access to the hash_secret