### PR TITLE
Remove set_plan permission

### DIFF
--- a/cfy_manager/components/restservice/config/authorization.conf
+++ b/cfy_manager/components/restservice/config/authorization.conf
@@ -1110,5 +1110,3 @@ permissions:
     - sys_admin
   set_plugin_update_details:
     - sys_admin
-  set_plan:
-    - sys_admin


### PR DESCRIPTION
It's not actually needed now as the endpoint that was going to use it
was changed to use a different approach.