### PR TITLE
Allow anyone access to IDP check

### DIFF
--- a/cfy_manager/components/restservice/config/authorization.conf
+++ b/cfy_manager/components/restservice/config/authorization.conf
@@ -1112,3 +1112,8 @@ permissions:
     - sys_admin
   identity_provider_get:
     - sys_admin
+    - manager
+    - user
+    - operations
+    - viewer
+    - default


### PR DESCRIPTION
This is to allow stage to use this endpoint for all users when
displaying things like 'set password'.

It's the same access permissions as ldap_status_get, and should
be about as sensitive.