### PR TITLE
CFY-3820 Clean up cluster services properly

### DIFF
--- a/cfy_manager/components/amqp_postgres/amqp_postgres.py
+++ b/cfy_manager/components/amqp_postgres/amqp_postgres.py
@@ -45,5 +45,5 @@ class AmqpPostgres(BaseComponent):
 
     def remove(self):
         logger.notice('Removing AMQP-Postgres...')
-        service.remove('cloudify-amqp-postgres', service_file=False)
+        service.remove('cloudify-amqp-postgres')
         logger.notice('AMQP-Postgres successfully removed')

--- a/cfy_manager/components/composer/composer.py
+++ b/cfy_manager/components/composer/composer.py
@@ -189,7 +189,7 @@ class Composer(BaseComponent):
 
     def remove(self):
         logger.notice('Removing Cloudify Composer...')
-        service.remove('cloudify-composer', service_file=False)
+        service.remove('cloudify-composer')
         logger.notice('Removing Composer data....')
         common.sudo(['rm', '-rf', '/opt/cloudify-composer'])
         logger.notice('Cloudify Composer successfully removed')

--- a/cfy_manager/components/execution_scheduler/execution_scheduler.py
+++ b/cfy_manager/components/execution_scheduler/execution_scheduler.py
@@ -39,5 +39,5 @@ class ExecutionScheduler(BaseComponent):
 
     def remove(self):
         logger.notice('Removing execution scheduler...')
-        service.remove('cloudify-execution-scheduler', service_file=False)
+        service.remove('cloudify-execution-scheduler')
         logger.notice('Execution scheduler successfully removed')

--- a/cfy_manager/components/mgmtworker/mgmtworker.py
+++ b/cfy_manager/components/mgmtworker/mgmtworker.py
@@ -125,6 +125,6 @@ class MgmtWorker(BaseComponent):
         self.start()
 
     def remove(self):
-        service.remove('cloudify-mgmtworker', service_file=False)
+        service.remove('cloudify-mgmtworker')
         common.remove('/opt/mgmtworker')
         common.remove(join(const.BASE_RESOURCES_PATH, MGMTWORKER))

--- a/cfy_manager/components/nginx/nginx.py
+++ b/cfy_manager/components/nginx/nginx.py
@@ -512,6 +512,9 @@ class Nginx(BaseComponent):
     def remove(self):
         remove_notice(NGINX)
         remove_logrotate(NGINX)
+        service.remove('nginx')
+        if self.service_type == 'supervisord':
+            service.remove('wait_on_restart')
         remove_files([
             join('/var/cache', NGINX),
             LOG_DIR,

--- a/cfy_manager/components/postgresql_server/postgresql_server.py
+++ b/cfy_manager/components/postgresql_server/postgresql_server.py
@@ -1658,6 +1658,7 @@ class PostgresqlServer(BaseComponent):
         self._configure_postgresql_server_service()
         if config[POSTGRESQL_SERVER]['cluster']['nodes']:
             self._configure_cluster()
+            service.remove(POSTGRES_SERVICE_NAME)
         else:
             self._init_postgresql_server()
             enable_remote_connections = \
@@ -1689,7 +1690,11 @@ class PostgresqlServer(BaseComponent):
             '/var/lib/pgsql/9.5/backups'  # might be missing
         ], ignore_failure=True)
         files.remove_notice(POSTGRESQL_SERVER)
-        service.remove(POSTGRES_SERVICE_NAME)
+        if config[POSTGRESQL_SERVER]['cluster']['nodes']:
+            service.remove('etcd')
+            service.remove('patroni')
+        else:
+            service.remove(POSTGRES_SERVICE_NAME)
         logger.info('Removing postgres bin links')
         files.remove_files(
             [os.path.join('/usr/sbin', pg_bin) for pg_bin in PG_BINS],

--- a/cfy_manager/components/rabbitmq/rabbitmq.py
+++ b/cfy_manager/components/rabbitmq/rabbitmq.py
@@ -631,7 +631,7 @@ class RabbitMQ(BaseComponent):
     def remove(self):
         logger.info('Stopping the Erlang Port Mapper Daemon...')
         sudo(['epmd', '-kill'], ignore_failures=True)
-        service.remove('cloudify-rabbitmq', service_file=False)
+        service.remove('cloudify-rabbitmq')
         logger.info('Removing rabbit data...')
         sudo(['rm', '-rf', '/var/lib/rabbitmq'])
         sudo(['rm', '-rf', '/etc/rabbitmq'])

--- a/cfy_manager/components/restservice/restservice.py
+++ b/cfy_manager/components/restservice/restservice.py
@@ -533,7 +533,8 @@ class RestService(BaseComponent):
             service.configure('cloudify-api', src_dir=RESTSERVICE)
 
     def remove(self):
-        service.remove('cloudify-restservice', service_file=False)
+        service.remove('cloudify-restservice')
+        service.remove('cloudify-api')
         remove_logrotate(RESTSERVICE)
         common.remove('/opt/manager')
 

--- a/cfy_manager/components/rsyslog/rsyslog.py
+++ b/cfy_manager/components/rsyslog/rsyslog.py
@@ -13,6 +13,7 @@ class Rsyslog(BaseComponent):
     def configure(self):
         if syslog.using_systemd_rsyslog():
             logger.notice('Using system rsyslog')
+            return
         logger.notice('Configuring Rsyslog...')
         syslog_wrapper = '''#!/bin/bash
 set -e

--- a/cfy_manager/components/stage/stage.py
+++ b/cfy_manager/components/stage/stage.py
@@ -214,7 +214,7 @@ class Stage(BaseComponent):
 
     def remove(self):
         logger.notice('Removing Stage...')
-        service.remove('cloudify-stage', service_file=False)
+        service.remove('cloudify-stage')
         logger.notice('Removing Stage data....')
         common.sudo(['rm', '-rf', '/opt/cloudify-stage'])
         logger.notice('Stage successfully removed')

--- a/cfy_manager/utils/service.py
+++ b/cfy_manager/utils/service.py
@@ -115,17 +115,12 @@ class SystemD(object):
         self.enable('{0}.service'.format(service_name),
                     ignore_failure=ignore_failure)
 
-    def remove(self, service_name, service_file=True):
+    def remove(self, service_name):
         """Stop and disable the service, and then delete its data
         """
         self.stop(service_name, ignore_failure=True)
         self.disable(service_name, ignore_failure=True)
-
-        # components that have had their unit file moved to the RPM, will
-        # also remove it during RPM uninstall
-        if service_file:
-            remove_file(self.get_service_file_path(service_name))
-
+        remove_file(self.get_service_file_path(service_name))
         remove_file(self.get_vars_file_path(service_name))
 
     @staticmethod
@@ -290,8 +285,6 @@ class Supervisord(object):
         for a given service_name.
         (e.g./etc/supervisord.d/rabbitmq.cloudify.conf)
         """
-        if service_name.startswith('cloudify-'):
-            service_name = service_name.split('-')[1]
         return "/etc/supervisord.d/{0}.cloudify.conf".format(service_name)
 
     def configure(self,
@@ -322,16 +315,12 @@ class Supervisord(object):
                    additional_render_context=external_configure_params)
             chown(user, group, dst)
 
-    def remove(self, service_name, service_file=True):
+    def remove(self, service_name):
         """Stop and disable the service, and then delete its data
         """
         self.stop(service_name, ignore_failure=True)
         self.disable(service_name, ignore_failure=True)
-
-        # components that have had their unit file moved to the RPM, will
-        # also remove it during RPM uninstall
-        if service_file:
-            remove_file(self.get_service_config_file_path(service_name))
+        remove_file(self.get_service_config_file_path(service_name))
 
     def reread(self):
         return self.supervisorctl('reread')
@@ -381,9 +370,9 @@ def restart(service_name, is_group=False, ignore_failure=False):
     return _get_backend().restart(service_name, is_group, ignore_failure)
 
 
-def remove(service_name, service_file=True):
+def remove(service_name):
     logger.debug('Removing service {0}...'.format(service_name))
-    return _get_backend().remove(service_name, service_file)
+    return _get_backend().remove(service_name)
 
 
 def reload(service_name, ignore_failure=False):


### PR DESCRIPTION
When uninstalling the cluster, we were leaving several services lying around.
This resulted in problems during reinstall.