### PR TITLE
RD-3990 DB server address for remote connections

### DIFF
--- a/cfy_manager/utils/db.py
+++ b/cfy_manager/utils/db.py
@@ -7,7 +7,6 @@ from cfy_manager.utils.common import (
     is_all_in_one_manager,
     run,
     service_is_in_config,
-    service_is_configured,
 )
 from ..config import config
 from cfy_manager.constants import (
@@ -51,7 +50,7 @@ def get_psql_env_and_base_command(logger, db_key='cloudify_db_name',
     pg_cluster_nodes = config[POSTGRESQL_SERVER]['cluster']['nodes']
     peer_authentication = False
 
-    if service_is_configured(DATABASE_SERVICE) and not pg_cluster_nodes:
+    if service_is_in_config(DATABASE_SERVICE) and not pg_cluster_nodes:
         # In case the default user is postgres and we're in AIO installation,
         # or if we're installing a single database node,
         # "peer" authentication is used


### PR DESCRIPTION
In case remote connections are enabled, we should be talking to
`private_ip`.