### PR TITLE
RD-4046 Print valid admin's password on exit

### DIFF
--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -552,8 +552,6 @@ def _print_finish_message(config_file=None):
                 protocol=protocol,
                 ip=manager_config[PUBLIC_IP])
         )
-        # reload the config in case the admin password changed
-        config.load_config(config_file)
         password = config[MANAGER][SECURITY][ADMIN_PASSWORD]
         print('Admin password: {0}'.format(password))
         print('#' * 50)


### PR DESCRIPTION
Because we gave up on saving the configuration file upon finishing
configuration
https://github.com/cloudify-cosmo/cloudify-manager-install/commit/f4a73b5c321c9411ee80968c12d6d51faad0b858#diff-f4fb19e547a01993edd4f655a5df9a8477d8a1b8f386ed50a60e26c0ab84db97
the password to display should no longer be read from the configuration
file, but from the current `config` instance.