### PR TITLE
CYBL-1439 Supervisord: honor config's extra_env

### DIFF
--- a/cfy_manager/components/restservice/config/supervisord/cloudify-restservice.conf
+++ b/cfy_manager/components/restservice/config/supervisord/cloudify-restservice.conf
@@ -6,4 +6,4 @@ command=/etc/cloudify/restservice-wrapper-script.sh {{ restservice.gunicorn.work
 environment=
     MANAGER_REST_CONFIG_PATH="{{ constants.REST_HOME_DIR }}/cloudify-rest.conf",
     MANAGER_REST_SECURITY_CONFIG_PATH="{{ constants.REST_HOME_DIR }}/rest-security.conf",
-    REST_PORT="{{ restservice.port }}"
+    REST_PORT="{{ restservice.port }}"{%- for key, value in restservice.extra_env.items() -%},{{ key }}="{{ value }}"{%- endfor -%}


### PR DESCRIPTION
config.yaml does declare extra_env on both restservice and the
mgmtworker, however only the mgmtworker actually renders it.

So make it go into the restservice config as well.

The line is pretty much just copied from the mgmtworker .conf