### PR TITLE
RD-4215 ensure_root: don't crash-and-burn on empty subcommands

### DIFF
--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -1408,7 +1408,7 @@ def _ensure_root():
         sys.argv.remove(skip_root_check)
     else:
         # Checking subcommands here so we never pass through --skip-root-check
-        if commands[1] in excluded_subcommands:
+        if len(commands) < 2 or commands[1] in excluded_subcommands:
             return
         if os.geteuid() != 0:
             sys.exit(subprocess.call(


### PR DESCRIPTION
Eg. `cfy_manager -h` doesn't need root, really.