### PR TITLE
RD-4188 Use extra_env for stage

### DIFF
--- a/cfy_manager/components/stage/config/cloudify-stage
+++ b/cfy_manager/components/stage/config/cloudify-stage
@@ -1,2 +1,5 @@
 STAGE_HOME=/opt/cloudify-stage
 STAGE_BACKEND_ARGS={{ community_mode }}
+{% for key, value in stage.extra_env.items() %}
+{{ key }}="{{ value }}"
+{% endfor %}

--- a/cfy_manager/components/stage/config/supervisord/cloudify-stage.conf
+++ b/cfy_manager/components/stage/config/supervisord/cloudify-stage.conf
@@ -10,4 +10,7 @@ environment=
     HOME="/opt/cloudify-stage",
     USER="{{ service_user }}",
     STAGE_HOME="/opt/cloudify-stage",
-    STAGE_BACKEND_ARGS="{{ community_mode }}"
+    STAGE_BACKEND_ARGS="{{ community_mode }}",
+{%- for key, value in stage.extra_env.items() %}
+    {{ key }}="{{ value }}",
+{%- endfor %}

--- a/config.yaml
+++ b/config.yaml
@@ -345,6 +345,8 @@ postgresql_client:
 stage:
   # If set to true, Cloudify UI will not be installed
   skip_installation: false
+  # Additional environment variables to add to stage's service file.
+  extra_env: {}
 
 composer:
   # If set to true, Cloudify Composer will not be installed


### PR DESCRIPTION
Similar to the mgmtworker and the restservice, extra_env allows
passing envvars to stage, most notably proxy settings