### PR TITLE
RD-4159 docker images: default to no-ssl

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -26,7 +26,7 @@ RUN curl -o /tmp/cloudify-manager-install.rpm $rpm_file \
     && rm /tmp/cloudify-manager-install.rpm \
     && cp /tmp/config.yaml /etc/cloudify/config.yaml \
     && cfy_manager install --only-install --verbose \
-    && sed -i 's/ssl_enabled: true/ssl_enabled: false/' /etc/cloudify/config.yaml \
+    && sed -i 's/ssl_enabled: true/ssl_enabled: false/' /opt/cloudify/cfy_manager/lib/python3.6/site-packages/config.yaml \
     && rm -fr /opt/cloudify/sources/*.rpm -fr \
     && rm /etc/yum.repos.d/Cloudify-Local.repo \
     && if [ "$autoremove" == "true" ]; then yum autoremove -y; fi \


### PR DESCRIPTION
In #1139, we disabled ssl for dockers, by changing the default
config.yaml - but in #1258 we stopped overwriting the config, so
we need to now change the default-default config.yaml.