### PR TITLE
RD-4433 apiservice: set the HOME envvar

### DIFF
--- a/cfy_manager/components/restservice/config/cloudify-api
+++ b/cfy_manager/components/restservice/config/cloudify-api
@@ -2,3 +2,4 @@
 GUNICORN_PORT={{ api.port }}
 GUNICORN_WORKER_COUNT={{ api.gunicorn.worker_count }}
 GUNICORN_MAX_REQUESTS={{ api.gunicorn.max_requests }}
+HOME="/etc/cloudify"

--- a/cfy_manager/components/restservice/config/supervisord/cloudify-api.conf
+++ b/cfy_manager/components/restservice/config/supervisord/cloudify-api.conf
@@ -3,4 +3,6 @@ user=root
 group=root
 stopasgroup=true
 autorestart=true
+environment=
+    HOME="/etc/cloudify",
 command=/etc/cloudify/api-wrapper-script.sh {{ api.gunicorn.worker_count }} {{ api.gunicorn.max_requests }} {{ api.port }}


### PR DESCRIPTION
If some certs are missing in the db url, but ssl is enabled, asyncpg
is going to look for them in ~/.postgresql

Unfortunately, that translates to /root/.postgresql, and asyncpg
dies with a permission denied. Let's set HOME so that it looks in
a directory it has access to.

You might ask, why not change the `user=root` then - because the
wrapper script needs to be able to create dirs in /run and whatever
else, and then it drops privileges anyway. And pathlib's `.home()`
goes by the HOME envvar first, before looking at the actual current
user. And that envvar otherwise just happens to be set to whatever
supervisord's was set, ie. /root