### PR TITLE
Only allow sys_admin to manage others tokens

### DIFF
--- a/cfy_manager/components/restservice/config/authorization.conf
+++ b/cfy_manager/components/restservice/config/authorization.conf
@@ -1144,6 +1144,5 @@ permissions:
     - viewer
   manage_others_tokens:
     - sys_admin
-    - manager
   inject_token:
     - sys_admin


### PR DESCRIPTION
They're system level not tenant level, so manager shouldn't have had it by default.