### PR TITLE
RD-4333 Drop `--clean-db` option to `cfy_manager`

### DIFF
--- a/cfy_manager/components/nginx/nginx.py
+++ b/cfy_manager/components/nginx/nginx.py
@@ -11,7 +11,6 @@ from ...components_constants import (
     PRIVATE_IP,
     PUBLIC_IP,
     SSL_INPUTS,
-    CLEAN_DB,
     HOSTNAME,
     SERVICES_TO_INSTALL
 )
@@ -279,11 +278,11 @@ class Nginx(BaseComponent):
 
     def _handle_certs(self):
         certs_handled = False
-        if config[CLEAN_DB] or not self._internal_certs_exist():
+        if not self._internal_certs_exist():
             certs_handled = True
             self._handle_internal_cert()
             prometheus.handle_certs()
-        if config[CLEAN_DB] or not self._external_certs_exist():
+        if not self._external_certs_exist():
             certs_handled = True
             self._handle_external_cert()
 

--- a/cfy_manager/components/restservice/restservice.py
+++ b/cfy_manager/components/restservice/restservice.py
@@ -20,7 +20,6 @@ from ...constants import (
 from ...components_constants import (
     CONFIG,
     SCRIPTS,
-    CLEAN_DB,
     SECURITY,
     SSL_INPUTS,
     CLUSTER_JOIN,
@@ -150,7 +149,7 @@ class RestService(BaseComponent):
     def _get_flask_security(self, flask_security_config):
         # If we're recreating the DB, or if there's no previous security
         # config file, just use the config that was generated
-        if config[CLEAN_DB] or not exists(REST_SECURITY_CONFIG_PATH):
+        if not exists(REST_SECURITY_CONFIG_PATH):
             return flask_security_config
 
         security_config = flask_security_config
@@ -242,9 +241,6 @@ class RestService(BaseComponent):
             'security_config': REST_SECURITY_CONFIG_PATH
         }
         config[CLUSTER_JOIN] = False
-
-        if config[CLEAN_DB]:
-            db.drop_db()
 
         if db.check_db_exists():
             db.validate_schema_version(configs)

--- a/cfy_manager/components_constants.py
+++ b/cfy_manager/components_constants.py
@@ -46,7 +46,6 @@ SSL_INPUTS = 'ssl_inputs'
 VALIDATIONS = 'validations'
 SKIP_VALIDATIONS = 'skip_validations'
 PROVIDER_CONTEXT = 'provider_context'
-CLEAN_DB = 'clean_db'
 FLASK_SECURITY = 'flask_security'
 UNCONFIGURED_INSTALL = 'unconfigured_install'
 

--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -22,7 +22,6 @@ from .components import (
     sources,
 )
 from .components_constants import (
-    CLEAN_DB,
     SECURITY,
     PUBLIC_IP,
     PRIVATE_IP,
@@ -108,12 +107,6 @@ TEST_CA_GENERATE_SAN_HELP_TEXT = (
     'Comma separated list of names or IPs that the generated certificate '
     'should be valid for. '
     'The first SAN entered will be the certificate name and used as the CN.'
-)
-CLEAN_DB_HELP_MSG = (
-    'If set to "false", the DB will not be recreated when '
-    'installing/configuring the Manager. Must be set to "true" on the first '
-    'installation. If set to "false", the hash salt and admin password '
-    'will not be generated'
 )
 ADMIN_PASSWORD_HELP_MSG = (
     'The password of the Cloudify Manager system administrator. '
@@ -510,10 +503,8 @@ sys.excepthook = _exception_handler
 
 
 def _populate_and_validate_config_values(private_ip, public_ip,
-                                         admin_password, clean_db):
+                                         admin_password):
     manager_config = config[MANAGER]
-
-    config[CLEAN_DB] = clean_db
 
     if private_ip:
         manager_config[PRIVATE_IP] = private_ip
@@ -527,7 +518,6 @@ def _prepare_execution(verbose=False,
                        private_ip=None,
                        public_ip=None,
                        admin_password=None,
-                       clean_db=False,
                        only_install=False,
                        config_file=None):
     setup_console_logger(verbose)
@@ -537,7 +527,7 @@ def _prepare_execution(verbose=False,
         # We don't validate anything that applies to the install anyway,
         # but we do populate things that are not relevant.
         _populate_and_validate_config_values(private_ip, public_ip,
-                                             admin_password, clean_db)
+                                             admin_password)
 
 
 def _print_finish_message(config_file=None):
@@ -714,7 +704,6 @@ def _filter_components(components, include_components):
 def install_args(f):
     """Apply all the args that are used by `cfy_manager install`"""
     args = [
-        argh.arg('--clean-db', help=CLEAN_DB_HELP_MSG),
         argh.arg('--private-ip', help=PRIVATE_IP_HELP_MSG),
         argh.arg('--public-ip', help=PUBLIC_IP_HELP_MSG),
         argh.arg('-a', '--admin-password', help=ADMIN_PASSWORD_HELP_MSG),
@@ -731,14 +720,12 @@ def validate_command(verbose=False,
                      private_ip=None,
                      public_ip=None,
                      admin_password=None,
-                     config_file=None,
-                     clean_db=False):
+                     config_file=None):
     _prepare_execution(
         verbose,
         private_ip,
         public_ip,
         admin_password,
-        clean_db,
         config_file=config_file,
     )
     components = _get_components()
@@ -830,7 +817,6 @@ def install(verbose=False,
             private_ip=None,
             public_ip=None,
             admin_password=None,
-            clean_db=False,
             only_install=None,
             config_file=None):
     """ Install Cloudify Manager """
@@ -840,7 +826,6 @@ def install(verbose=False,
         private_ip,
         public_ip,
         admin_password,
-        clean_db,
         config_file=config_file,
         only_install=only_install,
     )
@@ -877,8 +862,7 @@ def configure(verbose=False,
               private_ip=None,
               public_ip=None,
               admin_password=None,
-              config_file=None,
-              clean_db=False):
+              config_file=None):
     """ Configure Cloudify Manager """
 
     _prepare_execution(
@@ -886,7 +870,6 @@ def configure(verbose=False,
         private_ip,
         public_ip,
         admin_password,
-        clean_db,
         config_file=config_file,
     )
 
@@ -908,9 +891,6 @@ def configure(verbose=False,
     # This only relevant for restarting services on VM that use supervisord
     if is_supervisord_service():
         _configure_supervisord()
-    if clean_db:
-        for component in components:
-            component.stop()
 
     for component in components:
         component.configure()
@@ -1028,7 +1008,6 @@ def start(include_components,
           public_ip=None,
           admin_password=None,
           config_file=None,
-          clean_db=False,
           only_install=None):
     """ Start Cloudify Manager services """
     _prepare_execution(
@@ -1036,7 +1015,6 @@ def start(include_components,
         private_ip,
         public_ip,
         admin_password,
-        clean_db,
         config_file=config_file,
     )
     _validate_components_prepared('start', config_file)


### PR DESCRIPTION
... because instead of running configure (or install) with --clean-db,
one should rather remove installation with `cfy_manager remove` and only
then run `cfy_manager install`.