### PR TITLE
RD-4283 Install rsyslog

### DIFF
--- a/cfy_manager/components/sources.py
+++ b/cfy_manager/components/sources.py
@@ -26,7 +26,7 @@ manager_premium = [
 manager_cluster = []
 db = ['postgresql95', 'postgresql95-server', 'postgresql95-contrib', 'libxslt']
 db_cluster = [
-    'libestr', 'libfastjson', 'rsyslog', 'etcd', 'patroni'
+    'libestr', 'libfastjson', 'etcd', 'patroni'
 ]
 queue = ['rabbitmq-server-3.8.4', 'cloudify-rabbitmq']
 queue_cluster = []

--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -749,7 +749,7 @@ def sanity_check(verbose=False, private_ip=None, config_file=None):
 
 def _get_packages():
     """Yum packages to install/uninstall, based on the current config"""
-    packages = []
+    packages = ['rsyslog']
     packages_per_service_dict = {}
     # Adding premium components on all, even if we're on community, because
     # yum will return 0 (success) if any packages install successfully even if


### PR DESCRIPTION
If it was already installed, yum will cope by either updating it or
refusing to update it, which doesn't appear to affect the exit code.