### PR TITLE
RD-4712 Stop spurious supervisord CRIT log

### DIFF
--- a/packaging/files/etc/supervisord.conf
+++ b/packaging/files/etc/supervisord.conf
@@ -1,16 +1,23 @@
 [supervisord]
-stdout_syslog = true
+stdout_syslog = false
 stderr_syslog = true
+logfile = /var/log/cloudify/supervisord.log
 loglevel = info
 user = root
+nodaemon = true
+silent = true
 
 [unix_http_server]
 file = /var/run/supervisord.sock
 chmod = 0770
 chown = cfyuser:cfyuser
+username = stopspurious
+password = logmessages
 
 [supervisorctl]
 serverurl = unix:///var/run/supervisord.sock
+username = stopspurious
+password = logmessages
 
 [rpcinterface:supervisor]
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface


### PR DESCRIPTION
Even though the socket is secured by FS permissions, supervisord will
complain if the credentials aren't set.