### PR TITLE
Make is-active work with etcd again

### DIFF
--- a/cfy_manager/components/postgresql_server/postgresql_server.py
+++ b/cfy_manager/components/postgresql_server/postgresql_server.py
@@ -407,9 +407,7 @@ class PostgresqlServer(BaseComponent):
         return delim
 
     def _etcd_is_running(self):
-        status = service.is_active('etcd')
-        # Add new status 'running' for supervisord
-        return status in ('running', 'active', 'activating')
+        return service.is_active('etcd')
 
     def _start_etcd(self):
         # On the first node, etcd start via systemd will fail because of the

--- a/cfy_manager/utils/service.py
+++ b/cfy_manager/utils/service.py
@@ -23,6 +23,8 @@ from ..exceptions import ValidationError
 
 logger = get_logger('Service')
 
+ACTIVE_STATES = ['running', 'active', 'activating']
+
 
 class UnixSocketHTTPConnection(httplib.HTTPConnection):
     def connect(self):
@@ -161,7 +163,7 @@ class SystemD(object):
             'is-active',
             service_name,
             ignore_failure=True
-        ).aggr_stdout.strip().lower() == 'active'
+        ).aggr_stdout.strip().lower() in ACTIVE_STATES
 
     def is_installed(self, service_name):
         enabled = self.systemctl(
@@ -258,7 +260,7 @@ class Supervisord(object):
         return self.supervisorctl(
             'status', service_name,
             ignore_failure=True
-        ).aggr_stdout.strip().split()[1].lower()
+        ).aggr_stdout.strip().split()[1].lower() in ACTIVE_STATES
 
     def is_installed(self, service_name):
         status = self.supervisorctl(


### PR DESCRIPTION
It broke when is_active started behaving better by returning a bool.