### PR TITLE
RD-5562 cli profile hostname: fall back correctly

### DIFF
--- a/cfy_manager/components/cli/cli.py
+++ b/cfy_manager/components/cli/cli.py
@@ -123,6 +123,8 @@ class Cli(BaseComponent):
 
 
 def _local_profile_host_name():
-    if 'local_profile_host_name' in config.get(CLI, {}):
-        return config[CLI]['local_profile_host_name']
-    return config[MANAGER]['cli_local_profile_host_name']
+    try:
+        hostname = config[CLI]['local_profile_host_name']
+    except KeyError:
+        hostname = None
+    return hostname or config[MANAGER]['cli_local_profile_host_name']

--- a/cfy_manager/components/cli/cli.py
+++ b/cfy_manager/components/cli/cli.py
@@ -127,4 +127,4 @@ def _local_profile_host_name():
         hostname = config[CLI]['local_profile_host_name']
     except KeyError:
         hostname = None
-    return hostname or config[MANAGER]['cli_local_profile_host_name']
+    return hostname or config[MANAGER].get('cli_local_profile_host_name')


### PR DESCRIPTION
Heh, the previous impl. ended up returning the empty string, because
the field exists in the default config.yaml, but is, well, empty.

Which led to the one-level-higher using private ip instead of
manager.cli_local_profile_host_name