### PR TITLE
RD-5683 Use prerendered swagger docs

### DIFF
--- a/cfy_manager/components/nginx/config/rest-location.cloudify
+++ b/cfy_manager/components/nginx/config/rest-location.cloudify
@@ -2,6 +2,9 @@ location ~ ^/(blueprints|executions|deployments|nodes|events|status|provider|nod
     rewrite ^/(.*)$ /api/v1/$1;
 }
 location /api/ {
+    location ~* .help.json {
+       root /opt/manager/resources/cloudify/openapi/;
+    }
     include "/etc/nginx/conf.d/rest-proxy.cloudify";
 }
 


### PR DESCRIPTION
For now, swagger in restservice is disabled, in
cloudify-cosmo/cloudify-manager#3802

To keep the UI working, use prerendered jsons in the meantime