### PR TITLE
RD-5747 cli: use absolute path to cfy

### DIFF
--- a/cfy_manager/utils/common.py
+++ b/cfy_manager/utils/common.py
@@ -84,7 +84,7 @@ def cfy(*command, **kwargs):
     if as_user:
         base = ['sudo', '-E', '-u', as_user]
 
-    base.append('cfy')
+    base.append('/usr/bin/cfy')
     try:
         return run(base + list(command), env=env, **kwargs)
     except ProcessExecutionError as e:


### PR DESCRIPTION
Some users want to run the manager with a sudoers settings that
`secure_path` doesn't include `/usr/bin`. And so, then `cfy` is not
on the PATH.
We can just pass the absolute path here.