### PR TITLE
RD-5747 Don't require any secure_path at all

### DIFF
--- a/cfy_manager/components/composer/composer.py
+++ b/cfy_manager/components/composer/composer.py
@@ -54,14 +54,12 @@ class Composer(BaseComponent):
             logger.debug('Joining cluster - not creating the composer db')
             return
         backend_dir = join(HOME_DIR, 'backend')
-        npm_path = join('/usr', 'bin', 'npm')
         common.run(
             [
-                '/usr/bin/sudo', '-u', COMPOSER_USER, 'bash', '-c',
-                'cd {path}; {npm} run db-migrate'.format(
-                    path=backend_dir,
-                    npm=npm_path,
-                ),
+                '/usr/bin/sudo', '-u', COMPOSER_USER, '/usr/bin/bash', '-c',
+                # PATH can be empty, but npm internally requires /usr/bin
+                'cd {path}; PATH=/usr/bin npm run db-migrate'
+                .format(path=backend_dir),
             ],
         )
 

--- a/cfy_manager/components/stage/stage.py
+++ b/cfy_manager/components/stage/stage.py
@@ -58,14 +58,12 @@ class Stage(BaseComponent):
             logger.debug('Joining cluster - not creating the stage db')
             return
         backend_dir = join(HOME_DIR, 'backend')
-        npm_path = join('/usr', 'bin', 'npm')
         common.run(
             [
-                '/usr/bin/sudo', '-u', STAGE_USER, 'bash', '-c',
-                'cd {path}; {npm} run db-migrate'.format(
-                    path=backend_dir,
-                    npm=npm_path,
-                ),
+                '/usr/bin/sudo', '-u', STAGE_USER, '/usr/bin/bash', '-c',
+                # PATH can be empty, but npm internally requires /usr/bin
+                'cd {path}; PATH=/usr/bin npm run db-migrate'
+                .format(path=backend_dir),
             ],
         )
 

--- a/cfy_manager/components/validations.py
+++ b/cfy_manager/components/validations.py
@@ -245,10 +245,8 @@ def _validate_inputs():
 
 def _validate_user_has_sudo_permissions():
     current_user = getuser()
-    logger.info('Validating user `{0}` has sudo permissions...'.format(
-        current_user
-    ))
-    result = run(['/usr/bin/sudo', '-n', '/bin/true'])
+    logger.info('Validating user `%s` has sudo permissions...', current_user)
+    result = run(['/usr/bin/sudo', '--validate'])
     if result.returncode != 0:
         _errors.append(
             "Failed executing 'sudo'. Please ensure that the "

--- a/cfy_manager/components/validations.py
+++ b/cfy_manager/components/validations.py
@@ -248,7 +248,7 @@ def _validate_user_has_sudo_permissions():
     logger.info('Validating user `{0}` has sudo permissions...'.format(
         current_user
     ))
-    result = run(['/usr/bin/sudo', '-n', 'true'])
+    result = run(['/usr/bin/sudo', '-n', '/bin/true'])
     if result.returncode != 0:
         _errors.append(
             "Failed executing 'sudo'. Please ensure that the "

--- a/jenkins/Dockerfiles/test/Dockerfile
+++ b/jenkins/Dockerfiles/test/Dockerfile
@@ -1,0 +1,9 @@
+FROM cfy_manager_image
+
+# this is the docker image started in CI; here we can add some hardening,
+# so that we test an even stricter environment than we normally release
+
+# normally secure_path contains /sbin:/bin:/usr/sbin:/usr/bin
+# let's make it empty to test that we don't actually require any paths in it
+# (set it to /none - I wasn't able to find a way to make an empty string work)
+RUN sed -i 's/^Defaults    secure_path = .*/Defaults    secure_path = "\/none"/' /etc/sudoers

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -247,9 +247,12 @@ ls -la .
 pushd packaging/docker
   docker build --network host --build-arg  rpm_file=https://cloudify-release-eu.s3.amazonaws.com/cloudify/${env.S3_BUILD_PATH}/cloudify-manager-install-${env.VERSION}-${env.PRERELEASE}.el7.x86_64.rpm --tag ${env.IMAGE_NAME} .
 popd
+pushd jenkins/Dockerfiles/test
+  docker build -t test-manager-image .
+popd
 echo 'Run manager container'
 set -eux
-docker run --name ${env.CONTAINER_NAME} -d ${env.IMAGE_NAME}
+docker run --name ${env.CONTAINER_NAME} -d test-manager-image
 echo "Waiting for ${env.CONTAINER_NAME} to start"
 docker exec ${env.CONTAINER_NAME} cfy_manager wait-for-starter
 echo 'Check Manager status'


### PR DESCRIPTION
This ports #1395 to 6.4.1

There's only a few places where we sudo binaries with a non-absolute
path. We can just make them absolute and then we'll work with any
secure_path setting.

And so, in CI, let's actually test that "no secure_path" approach.
Now, we can CI-test stricter images than we normally build.