### PR TITLE
RD-5747 Add envvar validations

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -506,6 +506,18 @@ validations:
   # The supported versions of the above distros
   supported_distro_versions: ['7', '8']
 
+  # Environment variables that must be set. Values are regexps that the
+  # environment variable must contain, or a list of regexps.
+  expected_env:
+    PATH:
+      - "(^|:)/usr/local/sbin($|:)"
+      - "(^|:)/usr/local/bin($|:)"
+      - "(^|:)/usr/sbin($|:)"
+      - "(^|:)/usr/sbin($|:)"
+      - "(^|:)/usr/bin($|:)"
+      - "(^|:)/sbin($|:)"
+      - "(^|:)/bin($|:)"
+
 ssl_inputs:
   external_cert_path: ''
   external_key_path: ''


### PR DESCRIPTION
This ports #1398 to 6.4.1

Allow validating the env in general, by regexps. Also, include some
default validations for PATH.
