### PR TITLE
RD-5747 Make the PATH validation less strict

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -516,9 +516,6 @@ validations:
   # environment variable must contain, or a list of regexps.
   expected_env:
     PATH:
-      - "(^|:)/usr/local/sbin($|:)"
-      - "(^|:)/usr/local/bin($|:)"
-      - "(^|:)/usr/sbin($|:)"
       - "(^|:)/usr/sbin($|:)"
       - "(^|:)/usr/bin($|:)"
       - "(^|:)/sbin($|:)"


### PR DESCRIPTION
On some images, under sudo, /usr/local/{sbin,bin} isn't on the PATH,
but things seem to work. So it's not required.

Also remove the accidentally duplicated line. No need to check things
twice!