### PR TITLE
RD-5747 Make the PATH validation less strict

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -510,9 +510,6 @@ validations:
   # environment variable must contain, or a list of regexps.
   expected_env:
     PATH:
-      - "(^|:)/usr/local/sbin($|:)"
-      - "(^|:)/usr/local/bin($|:)"
-      - "(^|:)/usr/sbin($|:)"
       - "(^|:)/usr/sbin($|:)"
       - "(^|:)/usr/bin($|:)"
       - "(^|:)/sbin($|:)"


### PR DESCRIPTION
This ports #1400 to 6.4.1

On some images, under sudo, /usr/local/{sbin,bin} isn't on the PATH,
but things seem to work. So it's not required.

Also remove the accidentally duplicated line. No need to check things
twice!