### PR TITLE
RD-5982 Replace deprecated linux_distribution()

### DIFF
--- a/cfy_manager/components/validations.py
+++ b/cfy_manager/components/validations.py
@@ -44,9 +44,7 @@ _errors = []
 
 
 def _get_os_distro():
-    distribution, version, _ = \
-        distro.linux_distribution(full_distribution_name=False)
-    return distribution.lower(), version.split('.')[0]
+    return distro.id().lower(), distro.version().split('.')[0]
 
 
 def _get_host_total_memory():


### PR DESCRIPTION
`distro.linux_distribution()` is deprecated as of 1.6.0

https://github.com/python-distro/distro/blob/095882f9b4b397085c34c9bbe20ec05263b9e008/src/distro/distro.py#L159