### PR TITLE
RD-5984 Allow skipping filesystem replication

### DIFF
--- a/cfy_manager/components/composer/composer.py
+++ b/cfy_manager/components/composer/composer.py
@@ -153,6 +153,9 @@ class Composer(BaseComponent):
         wait_for_port(3000)
 
     def _chown_for_syncthing(self):
+        if not common.filesystem_replication_enabled():
+            logger.debug('FS replication disabled - skip composer chown')
+            return
         logger.info('Applying permissions changes for syncthing')
         common.chown(CLOUDIFY_USER, COMPOSER_GROUP, CONF_DIR)
         for excluded_file in ['db_ca.crt', 'prod.json']:

--- a/cfy_manager/components/prometheus/config/alerts/manager.yml
+++ b/cfy_manager/components/prometheus/config/alerts/manager.yml
@@ -6,11 +6,11 @@ groups:
       - record: manager_healthy
         expr: count by (host, monitor) (sum by (host, monitor) (probe_success) == {{ number_of_http_probes }})
       - record: manager_service_systemd
-        expr: sum by (host, name) (node_systemd_unit_state{name=~"(cloudify-amqp-postgres|blackbox_exporter|cloudify-composer|cloudify-stage|haproxy|cloudify-mgmtworker|cloudify-restservice|node_exporter|prometheus|cloudify-syncthing|cloudify-execution-scheduler|nginx|cloudify-api|cloudify-execution-scheduler).service", state="active"})
+        expr: sum by (host, name) (node_systemd_unit_state{name=~"(cloudify-amqp-postgres|blackbox_exporter|cloudify-composer|cloudify-stage|haproxy|cloudify-mgmtworker|cloudify-restservice|node_exporter|prometheus|{% if fs_replication %}cloudify-syncthing|{% endif %}cloudify-execution-scheduler|nginx|cloudify-api|cloudify-execution-scheduler).service", state="active"})
         labels:
           process_manager: systemd
       - record: manager_service_supervisord
-        expr: sum by (host, name) (node_supervisord_up{name=~"(cloudify-amqp-postgres|blackbox_exporter|cloudify-composer|cloudify-stage|haproxy|cloudify-mgmtworker|cloudify-restservice|node_exporter|prometheus|cloudify-syncthing|cloudify-execution-scheduler|nginx|cloudify-api|cloudify-execution-scheduler)"})
+        expr: sum by (host, name) (node_supervisord_up{name=~"(cloudify-amqp-postgres|blackbox_exporter|cloudify-composer|cloudify-stage|haproxy|cloudify-mgmtworker|cloudify-restservice|node_exporter|prometheus|{% if fs_replication %}cloudify-syncthing|{% endif %}cloudify-execution-scheduler|nginx|cloudify-api|cloudify-execution-scheduler)"})
         labels:
           process_manager: supervisord
       - record: manager_service

--- a/cfy_manager/components/prometheus/prometheus.py
+++ b/cfy_manager/components/prometheus/prometheus.py
@@ -544,6 +544,7 @@ def _deploy_alerts_configuration(number_of_http_probes, cluster_config,
         'all_in_one': common.is_all_in_one_manager(),
         'alert_for': _calculate_alert_for(
             config.get(PROMETHEUS, {}).get('scrape_interval')),
+        'fs_replication': common.filesystem_replication_enabled(),
     }
     manager_hosts = []
     rabbitmq_hosts = []

--- a/cfy_manager/components/restservice/restservice.py
+++ b/cfy_manager/components/restservice/restservice.py
@@ -492,6 +492,9 @@ class RestService(BaseComponent):
         if not common.is_only_manager_service_in_config():
             return
 
+        if not common.filesystem_replication_enabled():
+            return
+
         # this flag is set inside of restservice._configure_db
         to_join = config[CLUSTER_JOIN]
         if to_join:

--- a/cfy_manager/components/stage/stage.py
+++ b/cfy_manager/components/stage/stage.py
@@ -170,6 +170,9 @@ class Stage(BaseComponent):
         wait_for_port(8088)
 
     def _chown_for_syncthing(self):
+        if not common.filesystem_replication_enabled():
+            logger.debug('FS replication disabled - skip stage chown')
+            return
         logger.info('Applying permissions changes for syncthing')
         config_path = os.path.join(HOME_DIR, 'conf')
         common.chown(CLOUDIFY_USER, STAGE_GROUP, config_path)

--- a/cfy_manager/utils/common.py
+++ b/cfy_manager/utils/common.py
@@ -186,6 +186,10 @@ def is_only_manager_service_in_config():
             not service_is_in_config(QUEUE_SERVICE))
 
 
+def filesystem_replication_enabled():
+    return config[MANAGER].get('cluster_filesystem_replication')
+
+
 def allows_json_format():
     """Decorator for Argparse commands that allow a JSON format. This silences
     the given logger and outputs only at least at the ERROR level. Any inner

--- a/config.yaml
+++ b/config.yaml
@@ -32,6 +32,11 @@ manager:
   # For clusters this must be supplied, and will only be used, on the first manager
   cloudify_license_path: ''
 
+  # Whether to replicate the data stored on filesystem between worker nodes in
+  # a cluster. Disable this if the data is replicated using other means,
+  # eg. a shared volume.
+  # When not using a cluster, this setting is ignored.
+  cluster_filesystem_replication: true
 
 cli:
   # If set to true, Cloudify CLI will not be installed


### PR DESCRIPTION
If we know that the cluster uses some other method of replicating the filesystem, eg. using a shared volume, then there's no point in having syncthing running as well.

This allows a config flag to avoid configuring syncthing in these cases.

If the flag is false:
 - syncthing will not be configured & started
 - no additional chmods will be applied
 - monitoring configuration will not track syncthing's status

By default, replication is still enabled (no change from status quo)