### PR TITLE
RD-6073 Use configure_manager to create the admin user

### DIFF
--- a/cfy_manager/components/restservice/db.py
+++ b/cfy_manager/components/restservice/db.py
@@ -234,7 +234,7 @@ def run_script(script_name, script_input=None, configs=None):
     return _get_script_stdout(proc_result)
 
 
-def populate_db(configs):
+def populate_db(configs, additional_config_files=None):
     logger.notice('Populating DB and creating AMQP resources...')
     args_dict = _create_populate_db_args_dict()
     run_script('create_tables_and_add_defaults.py', args_dict, configs)
@@ -245,6 +245,9 @@ def populate_db(configs):
         args = ['manager_rest.configure_manager']
         for path in config['config_files']:
             args += ['--config-file-path', path]
+        if additional_config_files:
+            for path in additional_config_files:
+                args += ['--config-file-path', path]
         run_script_on_manager_venv('-m', script_args=args)
     logger.notice('DB populated and AMQP resources successfully created')
 

--- a/cfy_manager/components/restservice/db.py
+++ b/cfy_manager/components/restservice/db.py
@@ -127,8 +127,6 @@ def _create_populate_db_args_dict():
     script that creates and populates the DB to run
     """
     args_dict = {
-        'admin_username': config[MANAGER][SECURITY][ADMIN_USERNAME],
-        'admin_password': config[MANAGER][SECURITY][ADMIN_PASSWORD],
         'provider_context': _get_provider_context(),
         'permissions': _get_permissions(),
         'db_migrate_dir': join(constants.MANAGER_RESOURCES_HOME, 'cloudify',
@@ -240,6 +238,14 @@ def populate_db(configs):
     logger.notice('Populating DB and creating AMQP resources...')
     args_dict = _create_populate_db_args_dict()
     run_script('create_tables_and_add_defaults.py', args_dict, configs)
+    if (
+        config[MANAGER][SECURITY][ADMIN_USERNAME] and
+        config[MANAGER][SECURITY][ADMIN_PASSWORD]
+    ):
+        args = ['manager_rest.configure_manager']
+        for path in config['config_files']:
+            args += ['--config-file-path', path]
+        run_script_on_manager_venv('-m', script_args=args)
     logger.notice('DB populated and AMQP resources successfully created')
 
 

--- a/cfy_manager/components/restservice/scripts/create_tables_and_add_defaults.py
+++ b/cfy_manager/components/restservice/scripts/create_tables_and_add_defaults.py
@@ -14,10 +14,9 @@ from datetime import datetime
 from flask_migrate import upgrade
 
 from manager_rest import config, version
-from manager_rest.storage import storage_utils
 from manager_rest.amqp_manager import AMQPManager
 from manager_rest.flask_utils import setup_flask_app
-from manager_rest.storage import db, models, get_storage_manager  # NOQA
+from manager_rest.storage import db, models, get_storage_manager
 
 logging.basicConfig(
     stream=sys.stderr, level=logging.INFO, format='%(message)s')
@@ -54,15 +53,6 @@ def _populate_roles(data):
                 name=permission
             ))
     db.session.commit()
-
-
-def _add_default_user_and_tenant(amqp_manager, script_config):
-    logger.info('Creating bootstrap admin, default tenant and security roles')
-    storage_utils.create_default_user_tenant_and_roles(
-        admin_username=script_config['admin_username'],
-        admin_password=script_config['admin_password'],
-        amqp_manager=amqp_manager
-    )
 
 
 def _get_amqp_manager(script_config):
@@ -155,7 +145,6 @@ def _insert_cert(cert, name):
         name=name,
         value=cert,
         updated_at=datetime.now(),
-        _updater_id=0,
     )
     sm.put(inst)
     return inst.id
@@ -202,10 +191,6 @@ if __name__ == '__main__':
     if script_config.get('db_migrate_dir'):
         _init_db_tables(script_config['db_migrate_dir'])
         _populate_roles(script_config['permissions'])
-    if (script_config.get('admin_username')
-            and script_config.get('admin_password')):
-        amqp_manager = _get_amqp_manager(script_config)
-        _add_default_user_and_tenant(amqp_manager, script_config)
     if script_config.get('config'):
         _insert_config(script_config['config'])
     if script_config.get('rabbitmq_brokers'):

--- a/cfy_manager/config.py
+++ b/cfy_manager/config.py
@@ -82,22 +82,25 @@ class Config(CommentedMap):
         self._load_defaults_config()
         if not config_files:
             config_files = [DEFAULT_CONFIG_FILE_NAME]
+        cleaned_config_files = []
         for config_file in config_files:
             config_file_path = self._sanitized_config_path(config_file)
             if config_file_path:
                 logger.debug('Loading configuration from %s',
                              config_file_path)
                 self._load_user_config(config_file_path)
+                cleaned_config_files.append(config_file_path)
             else:
                 raise ValidationError(
                     'Expected configuration files to be in {0}, but '
                     'got: {1}'.format(CLOUDIFY_HOME_DIR, config_file))
-        self['config_files'] = config_files
+        self['config_files'] = cleaned_config_files
 
     def _sanitized_config_path(self, file_path):
         """Returns a file path in the CLOUDIFY_HOME_DIR or None."""
-        sanitized = abspath(join(CLOUDIFY_HOME_DIR, file_path))
-        return sanitized if sanitized.startswith(CLOUDIFY_HOME_DIR) else None
+        if not isabs(file_path):
+            file_path = abspath(join(CLOUDIFY_HOME_DIR, file_path))
+        return file_path if file_path.startswith(CLOUDIFY_HOME_DIR) else None
 
     def add_temp_path_to_clean(self, new_path_to_remove):
         paths_to_remove = self.setdefault(self.TEMP_PATHS, [])

--- a/cfy_manager/utils/scripts.py
+++ b/cfy_manager/utils/scripts.py
@@ -28,7 +28,7 @@ def run_script_on_manager_venv(script_path,
                                json_dump=True):
     """Runs a script in a separate process inside the Cloudify Manager's venv.
 
-    :param script_path: script absolute path.
+    :param script_path: script absolute path (or -m to run a module)
     :param script_input: script configuration to pass to the script. The path
      will be passed with the script_conf_arg param as an argument of the
      script - unless not provided.
@@ -38,7 +38,7 @@ def run_script_on_manager_venv(script_path,
     :param json_dump: if to json.dump the script_input.
     :return: process result of the run script.
     """
-    if not isfile(script_path):
+    if script_path != '-m' and not isfile(script_path):
         raise FileError('Provided script path "{0}" isn\'t a file or doesn\'t '
                         'exist.'.format(script_path))
     python_path = join(REST_HOME_DIR, 'env', 'bin', 'python')


### PR DESCRIPTION
Instead of creating the user+tenant in the script here, use the cloudify-manager module to do it.

Additionally:
 - store absolute paths to config files, instead of the current "filenames but in `/etc/cloudify` implicitly"
 - rewrite `dict_merge`

I do recommend viewing commits separately