### PR TITLE
drop duplicated `rabbitmq` sections in cluster CI

### DIFF
--- a/jenkins/cluster/manager2_config.yaml
+++ b/jenkins/cluster/manager2_config.yaml
@@ -6,19 +6,6 @@ manager:
     ssl_enabled: true
     admin_password: admin
 
-rabbitmq:
-  ca_path: /etc/cloudify/ca.pem
-  cluster_members:
-    rabbit1:
-      networks:
-        default: QUEUE1_IP
-    rabbit2:
-      networks:
-        default: QUEUE2_IP
-    rabbit3:
-      networks:
-        default: QUEUE3_IP
-
 postgresql_server:
   ssl_enabled: true
   ca_path: /etc/cloudify/ca.pem

--- a/jenkins/cluster/manager3_config.yaml
+++ b/jenkins/cluster/manager3_config.yaml
@@ -6,19 +6,6 @@ manager:
     ssl_enabled: true
     admin_password: admin
 
-rabbitmq:
-  ca_path: /etc/cloudify/ca.pem
-  cluster_members:
-    rabbit1:
-      networks:
-        default: QUEUE1_IP
-    rabbit2:
-      networks:
-        default: QUEUE2_IP
-    rabbit3:
-      networks:
-        default: QUEUE3_IP
-
 postgresql_server:
   ssl_enabled: true
   ca_path: /etc/cloudify/ca.pem

--- a/packaging/docker-rh8/starter.conf
+++ b/packaging/docker-rh8/starter.conf
@@ -6,6 +6,7 @@ stderr_logfile=/dev/fd/2
 stderr_logfile_maxbytes=0
 startsecs=0
 autorestart=false
+environment=LANG="en_US.utf-8",LC_ALL="C"
 
 [program:cron]
 command=/usr/sbin/crond -n

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -34,9 +34,6 @@ RUN curl -o /tmp/cloudify-manager-install.rpm $rpm_file \
     && if [ "$arch" != "aarch64" ]; then yum autoremove -y; fi \
     && yum clean all
 
-# ensure locale
-RUN echo -e "LANG=en_US.utf-8\nLC_ALL=C" > /etc/environment
-
 COPY starter.service /usr/lib/systemd/system/cloudify-starter.service
 RUN systemctl enable cloudify-starter.service
 

--- a/packaging/docker/starter.conf
+++ b/packaging/docker/starter.conf
@@ -6,6 +6,7 @@ stderr_logfile=/dev/fd/2
 stderr_logfile_maxbytes=0
 startsecs=0
 autorestart=false
+environment=LANG="en_US.utf-8",LC_ALL="C"
 
 [program:cron]
 command=/usr/sbin/crond -n


### PR DESCRIPTION
It should still be handled, but for right now, I wonder if this can actually be dropped now