### PR TITLE
RD-6289 Dockerfile: correct the rabbitmq port

### DIFF
--- a/packaging/docker-rh8/Dockerfile
+++ b/packaging/docker-rh8/Dockerfile
@@ -19,7 +19,7 @@ RUN yum install -y openssl-1.1.1k libselinux-utils \
     initscripts openssh-clients sudo \
     dbus-glib ncurses libpq compat-openssl10 iproute
 
-EXPOSE 80 443 5672 53333
+EXPOSE 80 443 5671 53333
 COPY $config /tmp/config.yaml
 
 # `curl && yum install && rm` is the method that results in the lowest

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN yum update -y && yum install -y openssl-1.0.2k libselinux-utils \
     initscripts tcp_wrappers-libs openssh-clients sudo \
     systemd-sysv  # systemd-sysv is required by postgres
 
-EXPOSE 80 443 5672 53333
+EXPOSE 80 443 5671 53333
 COPY $config /tmp/config.yaml
 
 # `curl && yum install && rm` is the method that results in the lowest


### PR DESCRIPTION
We don't use 5672, that'd be non-ssl. We always use ssl for rabbitmq.