### PR TITLE
RD-6291 Set supervisord logging level to `warn`

### DIFF
--- a/packaging/files/etc/supervisord.conf
+++ b/packaging/files/etc/supervisord.conf
@@ -3,7 +3,7 @@ stdout_logfile = NONE
 stderr_logfile = NONE
 stdout_syslog = true
 stderr_syslog = true
-loglevel = info
+loglevel = warn
 user = root
 
 [unix_http_server]


### PR DESCRIPTION
Let's silence all the "service started", "service stopped", "pid reaped" messages. Supervisord on INFO is just way too verbose.