### PR TITLE
RD-6292 Improve the manager is ready message

### DIFF
--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -60,6 +60,9 @@ from .constants import (
     INSTALLED_COMPONENTS,
     INSTALLED_PACKAGES,
     USER_CONFIG_PATH,
+    CA_CERT_FILENAME,
+    EXTERNAL_CA_CERT_FILENAME,
+    EXTERNAL_CA_CERT_PATH,
 )
 from .encryption.encryption import update_encryption_key
 from .exceptions import BootstrapError
@@ -647,16 +650,37 @@ def _prepare_execution(verbose=False,
 def _print_finish_message(config_file=None):
     if service_is_in_config(MANAGER_SERVICE):
         manager_config = config[MANAGER]
+        public_ip = manager_config[PUBLIC_IP] or manager_config[PRIVATE_IP]
         protocol = \
             'https' if config[MANAGER][SECURITY]['ssl_enabled'] else 'http'
-        logger.notice(
-            'Manager is up at {protocol}://{ip}'.format(
-                protocol=protocol,
-                ip=manager_config[PUBLIC_IP])
+        public_ip_message = 'Manager is up at {protocol}://{ip}'.format(
+            protocol=protocol,
+            ip=public_ip,
         )
         password = config[MANAGER][SECURITY][ADMIN_PASSWORD]
+        use_message = (
+            'cfy profiles use {ip} -u admin -p {password} -t default_tenant'
+            .format(
+                ip=public_ip,
+                password=password,
+            )
+        )
+        if protocol == 'https':
+            if os.path.exists(EXTERNAL_CA_CERT_PATH):
+                cert_filename = EXTERNAL_CA_CERT_FILENAME
+            else:
+                cert_filename = CA_CERT_FILENAME
+            use_message += ' -ssl -c path/to/' + cert_filename
+
+        print('#' * 50)
+        if public_ip:
+            print(public_ip_message)
         print('Admin password: {0}'.format(password))
         print('#' * 50)
+        if public_ip:
+            print('To connect to the manager, use:')
+            print(use_message)
+            print('#' * 50)
         print("To install the default plugins bundle run:")
         print("'cfy plugins bundle-upload'")
         print('#' * 50)
@@ -977,7 +1001,8 @@ def configure(verbose=False,
               private_ip=None,
               public_ip=None,
               admin_password=None,
-              config_file=None):
+              config_file=None,
+              print_finish_message=False):
     """ Configure Cloudify Manager """
 
     _prepare_execution(
@@ -1012,6 +1037,8 @@ def configure(verbose=False,
     config[UNCONFIGURED_INSTALL] = False
     logger.notice('Configuration finished successfully!')
     _finish_configuration(only_install=False)
+    if print_finish_message:
+        _print_finish_message(config_file=config_file)
 
 
 def _all_main_services_removed():
@@ -1316,7 +1343,7 @@ def image_starter(verbose=False, config_file=None):
     )
     config.load_config(config_file)
     executable = os.path.join(os.path.dirname(sys.executable), 'cfy_manager')
-    command = [executable, 'configure']
+    command = [executable, 'configure', '--print-finish-message']
     private_ip = config[MANAGER].get(PRIVATE_IP)
     if not private_ip:
         private_ip = _guess_private_ip()

--- a/cfy_manager/utils/service.py
+++ b/cfy_manager/utils/service.py
@@ -159,7 +159,6 @@ class Supervisord(object):
         src_dir = src_dir.replace('-', '_')
         srv_src = join(COMPONENTS_DIR, src_dir, config_path)
         srv_src = join(srv_src, '{0}.conf'.format(service_name))
-        logger.info('srv %s', srv_src)
         if exists(srv_src):
             logger.debug('Deploying supervisord service file...')
             deploy(srv_src, dst, render=render,


### PR DESCRIPTION
Improve the "Manager is ready" message shown after a manager has started.

Example output:
```
##################################################
Manager is up at https://172.17.0.2
Admin password: admin
##################################################
To connect to the manager, use:
cfy profiles use 172.17.0.2 -u admin -p admin -t default_tenant -ssl -c path/to/cloudify_internal_ca_cert.pem
##################################################
To install the default plugins bundle run:
'cfy plugins bundle-upload'
##################################################
```

- use "public_ip or private_ip" in case public ip isn't set
- if no ip is detected (eg. in `wait-for-starter`) just show nothing
  rather than showing an empty string
- no need for the `logger.notice`, let's only have the print, the notice
  didn't have the password anyway, and it only went to the logfile
- add an example `cfy` command for the user to copy. In case of SSL
  enabled, they'll have to figure out the cert, but not much we can
  do about that.
- also print that message in `image-starter`, so it's shown on just
  a `docker run` as well
- no need to print this on every `cfy_manager configure`
