### PR TITLE
RD-6290 Expose `/monitoring` on worker nodes

### DIFF
--- a/cfy_manager/components/nginx/config/rest-location.cloudify
+++ b/cfy_manager/components/nginx/config/rest-location.cloudify
@@ -11,3 +11,26 @@ location /api/ {
 location /api {
     return 404;
 }
+
+location /monitoring {
+    auth_request /monitoring-auth;
+    auth_basic "Cloudify Monitoring Service";
+    proxy_pass         http://cloudify-monitoring;
+    proxy_redirect     off;
+
+    proxy_set_header   Host              $host;
+    proxy_set_header   X-Real-IP         $remote_addr;
+    proxy_set_header   X-Server-Port     $server_port;
+    proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header   X-Forwarded-Proto $scheme;
+
+    gzip on;
+    gzip_types application/json;
+    gzip_min_length 1000;
+    gzip_proxied any;
+}
+
+location /monitoring-auth {
+    internal;
+    proxy_pass http://cloudify-rest/api/v3.1/monitoring-auth;
+}

--- a/cfy_manager/components/restservice/config/authorization.conf
+++ b/cfy_manager/components/restservice/config/authorization.conf
@@ -402,6 +402,12 @@ permissions:
   manager_manage:
     - sys_admin
 
+  # The `monitoring` permission allows the user to access prometheus
+  # under /monitoring.
+  # There is currently no finer-grained control.
+  monitoring:
+    - sys_admin
+
   broker_get:
     - sys_admin
     - manager


### PR DESCRIPTION
On worker nodes, we can expose the monitoring system behind the manager authentication, so that users can reach it easily.

For inter-cluster communication, the :8009 & separate credentials approach still stays, this just adds a more user-friendly way of getting to prometheus.