### PR TITLE
RD-6082 Additional plugins-base PATH for the mgmtworker

### DIFF
--- a/cfy_manager/components/mgmtworker/config/supervisord/cloudify-mgmtworker.conf
+++ b/cfy_manager/components/mgmtworker/config/supervisord/cloudify-mgmtworker.conf
@@ -8,6 +8,7 @@ stderr_syslog = true
 stopasgroup=true
 command=/opt/mgmtworker/env/bin/python -m mgmtworker.worker --queue "cloudify.management" --max-workers {{ mgmtworker.max_workers }} --hooks-queue "cloudify-hooks"
 environment=
+    PATH="{{ mgmtworker_path }}",
     HOME="/etc/cloudify",
     USER="cfyuser",
     MGMTWORKER_HOME="{{ constants.MGMWORKER_HOME_DIR }}",
@@ -25,4 +26,4 @@ environment=
     MANAGER_FILE_SERVER_URL="{{ manager.file_server_url }}",
     MANAGER_FILE_SERVER_ROOT="{{ manager.file_server_root }}",
     MAX_WORKERS="{{ mgmtworker.max_workers }}",
-    MIN_WORKERS="{{ mgmtworker.min_workers }}"{%- for key, value in mgmtworker.extra_env.items() -%},{{ key }}="{{ value }}"{%- endfor -%}{%- if postgresql_client.ssl_client_verification -%},PGSSLCERT={{ ssl_inputs.postgresql_client_cert_path }},PGSSLKEY={{ ssl_inputs.postgresql_client_key_path }}{%- endif -%}
+    MIN_WORKERS="{{ mgmtworker.min_workers }}"{%- for key, value in mgmtworker_extra_env.items() -%},{{ key }}="{{ value }}"{%- endfor -%}{%- if postgresql_client.ssl_client_verification -%},PGSSLCERT={{ ssl_inputs.postgresql_client_cert_path }},PGSSLKEY={{ ssl_inputs.postgresql_client_key_path }}{%- endif -%}

--- a/cfy_manager/components/mgmtworker/mgmtworker.py
+++ b/cfy_manager/components/mgmtworker/mgmtworker.py
@@ -1,5 +1,7 @@
+import os
 from os.path import join
 
+from ...config import config
 from ...components_constants import CONFIG
 from ..base_component import BaseComponent
 from ...service_names import MGMTWORKER
@@ -83,6 +85,30 @@ class MgmtWorker(BaseComponent):
         common.run(['chgrp', const.CLOUDIFY_GROUP, '/opt/manager'])
         common.run(['chmod', 'g+rw', '/opt/manager'])
 
+    def _mgmtworker_render_context(self):
+        """Find extra_env and the PATH based on config.
+
+        We'd like to add plugin base venvs into PATH, but there might be
+        already PATH set in extra_env by the user. In that case, let's still
+        include the user-provided PATH in the PATH that we render.
+        """
+        extra_env = dict(config[MGMTWORKER].get('extra_env') or {})
+        config_path = (
+            extra_env.pop('PATH', None)
+            or extra_env.pop('path', None)
+            or '$PATH'
+        )
+        mgmtworker_paths = [
+            # python-version specific virtualenvs are included in the
+            # mgmtworker
+            '/opt/plugins-common-3.6/bin',
+            config_path,
+        ]
+        return {
+            'mgmtworker_path': os.pathsep.join(mgmtworker_paths),
+            'mgmtworker_extra_env': extra_env,
+        }
+
     def upgrade(self):
         self._deploy_admin_token()
         super(MgmtWorker, self).upgrade()
@@ -90,7 +116,10 @@ class MgmtWorker(BaseComponent):
     def configure(self):
         logger.notice('Configuring Management Worker...')
         self._deploy_hooks_config()
-        service.configure('cloudify-mgmtworker')
+        service.configure(
+            'cloudify-mgmtworker',
+            additional_render_context=self._mgmtworker_render_context(),
+        )
         self._prepare_snapshot_permissions()
         self._deploy_admin_token()
         logger.notice('Management Worker successfully configured')

--- a/cfy_manager/components/mgmtworker/mgmtworker.py
+++ b/cfy_manager/components/mgmtworker/mgmtworker.py
@@ -96,7 +96,7 @@ class MgmtWorker(BaseComponent):
         config_path = (
             extra_env.pop('PATH', None)
             or extra_env.pop('path', None)
-            or '$PATH'
+            or '%(ENV_PATH)s'
         )
         mgmtworker_paths = [
             # python-version specific virtualenvs are included in the

--- a/cfy_manager/components/mgmtworker/mgmtworker.py
+++ b/cfy_manager/components/mgmtworker/mgmtworker.py
@@ -118,7 +118,7 @@ class MgmtWorker(BaseComponent):
         self._deploy_hooks_config()
         service.configure(
             'cloudify-mgmtworker',
-            additional_render_context=self._mgmtworker_render_context(),
+            external_configure_params=self._mgmtworker_render_context(),
         )
         self._prepare_snapshot_permissions()
         self._deploy_admin_token()


### PR DESCRIPTION
We include a python-3.6 venv in the mgmtworker, with a base for plugin installations.