### PR TITLE
RD-6541 Move creating permissions to cloudify-manager

### DIFF
--- a/cfy_manager/components/restservice/db.py
+++ b/cfy_manager/components/restservice/db.py
@@ -31,7 +31,6 @@ from ...exceptions import ValidationError
 from ...utils import common
 from ...utils.db import run_psql_command
 from ...utils.install import is_premium_installed
-from ...utils.files import read_yaml_file
 from ...utils.scripts import run_script_on_manager_venv
 
 logger = get_logger('DB')
@@ -116,10 +115,6 @@ def _get_provider_context():
     return context
 
 
-def _get_permissions():
-    return read_yaml_file(join(CONFIG_PATH, 'authorization.conf'))
-
-
 def _create_populate_db_args_dict():
     """
     Create and return a dictionary with all the information necessary for the
@@ -127,7 +122,6 @@ def _create_populate_db_args_dict():
     """
     args_dict = {
         'provider_context': _get_provider_context(),
-        'permissions': _get_permissions(),
         'db_migrate_dir': join(constants.MANAGER_RESOURCES_HOME, 'cloudify',
                                'migrations'),
         'config': make_manager_config(),
@@ -217,6 +211,7 @@ def populate_db(configs, additional_config_files=None):
         config[MANAGER][SECURITY][ADMIN_PASSWORD]
     ):
         args = ['manager_rest.configure_manager']
+        args += ['--config-file-path', join(CONFIG_PATH, 'authorization.conf')]
         for path in config['config_files']:
             args += ['--config-file-path', path]
         if additional_config_files:

--- a/cfy_manager/components/restservice/scripts/create_tables_and_add_defaults.py
+++ b/cfy_manager/components/restservice/scripts/create_tables_and_add_defaults.py
@@ -32,26 +32,6 @@ def _init_db_tables(db_migrate_dir):
     upgrade(directory=db_migrate_dir)
 
 
-def _populate_roles(data):
-    for role in data['roles']:
-        db.session.add(models.Role(
-            name=role['name'],
-            type=role['type'],
-            description=role['description']
-        ))
-    roles = {r.name: r.id for r in
-             db.session.query(models.Role.name, models.Role.id)}
-    for permission, permission_roles in data['permissions'].items():
-        for role_name in permission_roles:
-            if role_name not in roles:
-                continue
-            db.session.add(models.Permission(
-                role_id=roles[role_name],
-                name=permission
-            ))
-    db.session.commit()
-
-
 def _insert_config(config):
     sm = get_storage_manager()
     for scope, entries in config:
@@ -164,7 +144,6 @@ if __name__ == '__main__':
 
     if script_config.get('db_migrate_dir'):
         _init_db_tables(script_config['db_migrate_dir'])
-        _populate_roles(script_config['permissions'])
     if script_config.get('config'):
         _insert_config(script_config['config'])
     if script_config.get('manager'):


### PR DESCRIPTION
After cloudify-cosmo/cloudify-manager#3961 the permissions & roles are just created in configure_manager.py, based on the config.

So I'll just pass authorization.conf as yet another config file. It'll get merged with the other config.yaml files.

We can do this, because config.yaml currently has no `roles:` and `permissions:` top-level keys.

That also means that you can now override your roles & permissions using just config.yaml. Nifty.