### PR TITLE
Create ProviderContext in configure_manager

### DIFF
--- a/cfy_manager/components/restservice/db.py
+++ b/cfy_manager/components/restservice/db.py
@@ -109,7 +109,7 @@ def _create_database(db_name, user):
         'server_db_name', logger)
 
 
-def _get_provider_context():
+def get_provider_context():
     context = {'cloudify': config[PROVIDER_CONTEXT]}
     context['cloudify']['cloudify_agent'] = config[AGENT]
     return context
@@ -121,7 +121,6 @@ def _create_populate_db_args_dict():
     script that creates and populates the DB to run
     """
     args_dict = {
-        'provider_context': _get_provider_context(),
         'db_migrate_dir': join(constants.MANAGER_RESOURCES_HOME, 'cloudify',
                                'migrations'),
         'config': make_manager_config(),

--- a/cfy_manager/components/restservice/scripts/create_tables_and_add_defaults.py
+++ b/cfy_manager/components/restservice/scripts/create_tables_and_add_defaults.py
@@ -104,16 +104,6 @@ def _insert_cert(cert, name):
     return inst.id
 
 
-def _add_provider_context(context):
-    sm = get_storage_manager()
-    provider_context = models.ProviderContext(
-        id='CONTEXT',
-        name='provider',
-        context=context
-    )
-    sm.put(provider_context)
-
-
 def file_path(path):
     if os.path.exists(path):
         return path
@@ -148,8 +138,6 @@ if __name__ == '__main__':
         _insert_config(script_config['config'])
     if script_config.get('manager'):
         _insert_manager(script_config['manager'])
-    if script_config.get('provider_context'):
-        _add_provider_context(script_config['provider_context'])
     if script_config.get('db_nodes'):
         _insert_db_nodes(script_config['db_nodes'])
     if script_config.get('usage_collector'):


### PR DESCRIPTION
Move this out of the create_tables.py script, and into the... well, the other script. Now we are going to pass that through. And refactor the passing-through part a bit, too.