### PR TITLE
RD-6566 Move inserting manager to configure_manager.py

### DIFF
--- a/cfy_manager/components/restservice/db.py
+++ b/cfy_manager/components/restservice/db.py
@@ -115,7 +115,7 @@ def get_provider_context():
     return context
 
 
-def _create_populate_db_args_dict():
+def create_populate_db_args_dict():
     """
     Create and return a dictionary with all the information necessary for the
     script that creates and populates the DB to run
@@ -203,7 +203,7 @@ def run_script(script_name, script_input=None, configs=None):
 
 def populate_db(configs, additional_config_files=None):
     logger.notice('Populating DB and creating AMQP resources...')
-    args_dict = _create_populate_db_args_dict()
+    args_dict = create_populate_db_args_dict()
     run_script('create_tables_and_add_defaults.py', args_dict, configs)
     if (
         config[MANAGER][SECURITY][ADMIN_USERNAME] and
@@ -220,7 +220,7 @@ def populate_db(configs, additional_config_files=None):
     logger.notice('DB populated and AMQP resources successfully created')
 
 
-def _get_manager():
+def get_manager():
     try:
         with open(constants.CA_CERT_PATH) as f:
             ca_cert = f.read()
@@ -232,22 +232,22 @@ def _get_manager():
         'private_ip': config['manager']['private_ip'],
         'networks': config[NETWORKS],
         'last_seen': common.get_formatted_timestamp(),
-        'ca_cert': ca_cert
+        'ca_cert': ca_cert,
+        SECURITY: {
+            ADMIN_PASSWORD: config[MANAGER][SECURITY][ADMIN_PASSWORD],
+        },
     }
 
 
 def insert_manager(configs):
     logger.notice('Registering manager in the DB...')
-    args = {'manager': _get_manager()}
-    run_script('create_tables_and_add_defaults.py', args, configs)
+    args = {'manager': get_manager()}
+    run_script('update_stored_manager.py', args, configs)
 
 
 def update_stored_manager(configs=None):
     logger.notice('Updating stored manager...')
-    args = {
-        'manager': _get_manager(),
-        'admin_password': config[MANAGER][SECURITY][ADMIN_PASSWORD],
-    }
+    args = {'manager': get_manager()}
 
     run_script('update_stored_manager.py', args, configs=configs)
     logger.notice('AMQP resources successfully created')

--- a/cfy_manager/components/restservice/scripts/create_tables_and_add_defaults.py
+++ b/cfy_manager/components/restservice/scripts/create_tables_and_add_defaults.py
@@ -6,12 +6,10 @@ import sys
 import json
 import logging
 import argparse
-import subprocess
-from datetime import datetime
 
 from flask_migrate import upgrade
 
-from manager_rest import config, version
+from manager_rest import config
 from manager_rest.flask_utils import setup_flask_app
 from manager_rest.storage import db, models, get_storage_manager
 
@@ -53,57 +51,6 @@ def _insert_usage_collector(usage_collector_info):
     sm.put(models.UsageCollector(**usage_collector_info))
 
 
-def _insert_manager(config):
-    sm = get_storage_manager()
-    ca_cert = config.get('ca_cert')
-    try:
-        stored_cert = sm.list(models.Manager)[0].ca_cert
-    except IndexError:
-        stored_cert = None
-
-    if not stored_cert and not ca_cert:
-        raise RuntimeError('No manager certs found, and ca_cert not given')
-    if stored_cert and not ca_cert:
-        with open(CA_CERT_PATH, 'w') as f:
-            f.write(stored_cert.value)
-        subprocess.check_call(['/usr/bin/sudo', 'chown', 'cfyuser.',
-                               CA_CERT_PATH])
-        subprocess.check_call(['/usr/bin/sudo', 'chmod', '444', CA_CERT_PATH])
-        ca = stored_cert.id
-    elif ca_cert and not stored_cert:
-        ca = _insert_cert(ca_cert, '{0}-ca'.format(config['hostname']))
-    else:
-        if stored_cert.value.strip() != ca_cert.strip():
-            raise RuntimeError('ca_cert differs from existing manager CA')
-        ca = stored_cert.id
-
-    version_data = version.get_version_data()
-    inst = models.Manager(
-        public_ip=config['public_ip'],
-        hostname=config['hostname'],
-        private_ip=config['private_ip'],
-        networks=config['networks'],
-        edition=version_data['edition'],
-        version=version_data['version'],
-        distribution=version_data['distribution'],
-        distro_release=version_data['distro_release'],
-        _ca_cert_id=ca,
-        last_seen=config['last_seen'],
-    )
-    sm.put(inst)
-
-
-def _insert_cert(cert, name):
-    sm = get_storage_manager()
-    inst = models.Certificate(
-        name=name,
-        value=cert,
-        updated_at=datetime.now(),
-    )
-    sm.put(inst)
-    return inst.id
-
-
 def file_path(path):
     if os.path.exists(path):
         return path
@@ -136,8 +83,6 @@ if __name__ == '__main__':
         _init_db_tables(script_config['db_migrate_dir'])
     if script_config.get('config'):
         _insert_config(script_config['config'])
-    if script_config.get('manager'):
-        _insert_manager(script_config['manager'])
     if script_config.get('db_nodes'):
         _insert_db_nodes(script_config['db_nodes'])
     if script_config.get('usage_collector'):

--- a/cfy_manager/components/restservice/scripts/update_stored_manager.py
+++ b/cfy_manager/components/restservice/scripts/update_stored_manager.py
@@ -117,10 +117,6 @@ def main(new_manager):
     db.session.commit()
 
     config.instance.load_configuration()
-    amqp_manager = _get_amqp_manager()
-    default_tenant = models.Tenant.query.filter_by(name='default_tenant').one()
-    amqp_manager.create_tenant_vhost_and_user(default_tenant)
-    amqp_manager.sync_metadata()
     if controller:
         controller.add_manager(models.Manager.query.all())
     if agents:

--- a/cfy_manager/components/restservice/scripts/update_stored_manager.py
+++ b/cfy_manager/components/restservice/scripts/update_stored_manager.py
@@ -121,12 +121,6 @@ def main(new_manager):
         controller.add_manager(models.Manager.query.all())
     if agents:
         agents.update_agents(get_storage_manager())
-    try:
-        admin_password = new_manager['security']['admin_password']
-    except KeyError:
-        admin_password = None
-    if admin_password:
-        _update_admin_password(admin_password)
 
 
 if __name__ == '__main__':

--- a/cfy_manager/components/restservice/scripts/update_stored_manager.py
+++ b/cfy_manager/components/restservice/scripts/update_stored_manager.py
@@ -5,11 +5,15 @@ import uuid
 from datetime import datetime
 from flask_security.utils import hash_password, verify_password
 
-from manager_rest import config
+from manager_rest import config, version
 from manager_rest.amqp_manager import AMQPManager
-from manager_rest.constants import DEFAULT_TENANT_ID
 from manager_rest.flask_utils import setup_flask_app
-from manager_rest.storage import models, get_storage_manager, user_datastore
+from manager_rest.storage import (
+    db,
+    models,
+    get_storage_manager,
+    user_datastore,
+)
 try:
     from cloudify_premium.ha import agents
     from cloudify_premium.ha import controller
@@ -27,7 +31,7 @@ def _get_amqp_manager():
     )
 
 
-def _update_cert(sm, manager, broker, new_cert_value):
+def _update_cert(manager, broker, new_cert_value):
     old_cert = manager.ca_cert
     if old_cert.value == new_cert_value:
         return
@@ -35,14 +39,14 @@ def _update_cert(sm, manager, broker, new_cert_value):
     new_cert = models.Certificate(
         name=str(uuid.uuid4()),
         value=new_cert_value,
-        updated_at=datetime.now(),
+        updated_at=datetime.utcnow(),
         _updater_id=0
     )
     manager.ca_cert = new_cert
     if broker:
         broker.ca_cert = new_cert
     if not old_cert.managers and not old_cert.rabbitmq_brokers:
-        sm.delete(old_cert)
+        db.session.delete(old_cert)
 
 
 def _update_admin_password(new_password):
@@ -53,19 +57,17 @@ def _update_admin_password(new_password):
     user_datastore.commit()
 
 
-def main(new_manager, admin_password):
-    sm = get_storage_manager()
-
+def main(new_manager):
     hostname = new_manager['hostname']
-    manager = sm.get(models.Manager, None, filters={'hostname': hostname})
-    broker = sm.get(models.RabbitMQBroker, None, filters={
-        'name': hostname,
-        'host': manager.private_ip
-    }, fail_silently=True)
-    db_node = sm.get(models.DBNodes, None, filters={
-        'name': hostname,
-        'host': manager.private_ip
-    }, fail_silently=True)
+    version_data = version.get_version_data()
+
+    manager = models.Manager.query.filter_by(hostname=hostname).first()
+    if manager is None:
+        manager = models.Manager(
+            hostname=hostname,
+            networks={},
+        )
+        db.session.add(manager)
 
     new_networks = manager.networks.copy()
     for name, ip in new_networks.items():
@@ -80,31 +82,51 @@ def main(new_manager, admin_password):
     manager.networks = new_networks
     for attr in ['private_ip', 'public_ip']:
         setattr(manager, attr, new_manager[attr])
+    manager.version = version_data.get('version')
+    manager.edition = version_data.get('edition')
+    manager.distribution = version_data.get('distribution')
+    manager.distro_release = version_data.get('distro_release')
+    manager.last_seen = datetime.utcnow()
 
-    sm.update(manager)
+    broker = (
+        models.RabbitMQBroker.query
+        .filter_by(name=hostname, host=manager.private_ip)
+        .first()
+    )
+
     if broker:
         if broker.management_host == broker.host:
             broker.management_host = manager.private_ip
         broker.host = manager.private_ip
         broker.networks = manager.networks
-        sm.update(broker)
+
+    db_node = (
+        models.DBNodes.query
+        .filter_by(name=hostname, host=manager.private_ip)
+        .all()
+    )
 
     if db_node:
         db_node.host = manager.private_ip
-        sm.update(db_node)
 
     if new_manager.get('ca_cert'):
-        _update_cert(sm, manager, broker, new_manager['ca_cert'])
+        _update_cert(manager, broker, new_manager['ca_cert'])
+
+    db.session.commit()
 
     config.instance.load_configuration()
     amqp_manager = _get_amqp_manager()
-    default_tenant = sm.get(models.Tenant, DEFAULT_TENANT_ID)
+    default_tenant = models.Tenant.query.filter_by(name='default').one()
     amqp_manager.create_tenant_vhost_and_user(default_tenant)
     amqp_manager.sync_metadata()
     if controller:
-        controller.add_manager(sm.list(models.Manager))
+        controller.add_manager(models.Manager.query.all())
     if agents:
-        agents.update_agents(sm)
+        agents.update_agents(get_storage_manager())
+    try:
+        admin_password = new_manager['security']['admin_password']
+    except KeyError:
+        admin_password = None
     if admin_password:
         _update_admin_password(admin_password)
 
@@ -129,4 +151,4 @@ if __name__ == '__main__':
         secret_key=config.instance.security_secret_key
     ).app_context():
         config.instance.load_configuration()
-        main(inputs['manager'], inputs.get('admin_password'))
+        main(inputs['manager'])

--- a/cfy_manager/components/restservice/scripts/update_stored_manager.py
+++ b/cfy_manager/components/restservice/scripts/update_stored_manager.py
@@ -118,7 +118,7 @@ def main(new_manager):
 
     config.instance.load_configuration()
     amqp_manager = _get_amqp_manager()
-    default_tenant = models.Tenant.query.filter_by(name='default').one()
+    default_tenant = models.Tenant.query.filter_by(name='default_tenant').one()
     amqp_manager.create_tenant_vhost_and_user(default_tenant)
     amqp_manager.sync_metadata()
     if controller:

--- a/cfy_manager/components/restservice/scripts/update_stored_manager.py
+++ b/cfy_manager/components/restservice/scripts/update_stored_manager.py
@@ -67,7 +67,6 @@ def main(new_manager):
             hostname=hostname,
             networks={},
         )
-        db.session.add(manager)
 
     new_networks = manager.networks.copy()
     for name, ip in new_networks.items():
@@ -109,6 +108,7 @@ def main(new_manager):
     if db_node:
         db_node.host = manager.private_ip
 
+    db.session.add(manager)
     if new_manager.get('ca_cert'):
         _update_cert(manager, broker, new_manager['ca_cert'])
 

--- a/cfy_manager/components/restservice/scripts/update_stored_manager.py
+++ b/cfy_manager/components/restservice/scripts/update_stored_manager.py
@@ -33,7 +33,7 @@ def _get_amqp_manager():
 
 def _update_cert(manager, broker, new_cert_value):
     old_cert = manager.ca_cert
-    if old_cert.value == new_cert_value:
+    if old_cert and old_cert.value == new_cert_value:
         return
 
     new_cert = models.Certificate(
@@ -45,6 +45,8 @@ def _update_cert(manager, broker, new_cert_value):
     manager.ca_cert = new_cert
     if broker:
         broker.ca_cert = new_cert
+    if not old_cert:
+        return
     if not old_cert.managers and not old_cert.rabbitmq_brokers:
         db.session.delete(old_cert)
 


### PR DESCRIPTION
This is not trivial, and I also refactor a bit, so it's not gonna be very easy to review; sorry about that, but I wasn't able to come up with a better way :)

The point is taking that `_insert_manager` out of
create_tables_and_add_defaults.py, and moving it to the cloudify-manager side.

Alas, that script was also used for inserting a new manager into an already-existing db, in a cluster. cloudify-manager's configure_manager.py can do that as well, and does, but for now I'd like to limit the changes here to a minimum, so I'll still keep a `def insert_manager` here.

But let's use the `update_stored_manager.py` script for inserting it. And so, that `update` now really means `upsert`. So I'm refactoring that script a bit as well.

And restservice.py's `_configure_db` is a bit nicer now as well...