### PR TITLE
RD-6614 Configure mgmtworker's resources dir

### DIFF
--- a/cfy_manager/components/mgmtworker/config/cloudify-mgmtworker
+++ b/cfy_manager/components/mgmtworker/config/cloudify-mgmtworker
@@ -14,6 +14,7 @@ MANAGER_FILE_SERVER_URL="{{ manager.file_server_url }}"
 MANAGER_FILE_SERVER_ROOT="{{ manager.file_server_root }}"
 MAX_WORKERS="{{ mgmtworker.max_workers }}"
 MIN_WORKERS="{{ mgmtworker.min_workers }}"
+CFY_RESOURCES_ROOT="{{ mgmtworker.resources_root }}"
 {% for key, value in mgmtworker.extra_env.items() %}
 {{ key }}="{{ value }}"
 {% endfor %}

--- a/cfy_manager/components/mgmtworker/config/supervisord/cloudify-mgmtworker.conf
+++ b/cfy_manager/components/mgmtworker/config/supervisord/cloudify-mgmtworker.conf
@@ -26,4 +26,5 @@ environment=
     MANAGER_FILE_SERVER_URL="{{ manager.file_server_url }}",
     MANAGER_FILE_SERVER_ROOT="{{ manager.file_server_root }}",
     MAX_WORKERS="{{ mgmtworker.max_workers }}",
-    MIN_WORKERS="{{ mgmtworker.min_workers }}"{%- for key, value in mgmtworker_extra_env.items() -%},{{ key }}="{{ value }}"{%- endfor -%}{%- if postgresql_client.ssl_client_verification -%},PGSSLCERT={{ ssl_inputs.postgresql_client_cert_path }},PGSSLKEY={{ ssl_inputs.postgresql_client_key_path }}{%- endif -%}
+    MIN_WORKERS="{{ mgmtworker.min_workers }}",
+    CFY_RESOURCES_ROOT="{{ mgmtworker.resources_root }}"{%- for key, value in mgmtworker_extra_env.items() -%},{{ key }}="{{ value }}"{%- endfor -%}{%- if postgresql_client.ssl_client_verification -%},PGSSLCERT={{ ssl_inputs.postgresql_client_cert_path }},PGSSLKEY={{ ssl_inputs.postgresql_client_key_path }}{%- endif -%}

--- a/config.yaml
+++ b/config.yaml
@@ -490,6 +490,9 @@ mgmtworker:
     # Sets the interval between retry attempts in seconds.
     task_retry_interval: 15
 
+  # A local copy of Cloudify resources (e.g. deployment working directories)
+  resources_root: /tmp/resources
+
 sanity:
   # If set to true, the sanity blueprint install/uninstall will not be
   # performed during Cloudify Manager installation

--- a/config.yaml
+++ b/config.yaml
@@ -491,7 +491,7 @@ mgmtworker:
     task_retry_interval: 15
 
   # A local copy of Cloudify resources (e.g. deployment working directories)
-  resources_root: /tmp/resources
+  resources_root: /opt/manager/resources
 
 sanity:
   # If set to true, the sanity blueprint install/uninstall will not be


### PR DESCRIPTION
The directory is used for keeping local copies of manager's resources. Currently mgmworker will download deployment working directory before attempting to execute any operations or workflows.  Afterwards it will upload the directory back to the manager.