### PR TITLE
RD-6717 Monitoring auth: redirect to stage on error

### DIFF
--- a/cfy_manager/components/nginx/config/rest-location.cloudify
+++ b/cfy_manager/components/nginx/config/rest-location.cloudify
@@ -14,7 +14,6 @@ location /api {
 
 location /monitoring {
     auth_request /monitoring-auth;
-    auth_basic "Cloudify Monitoring Service";
     proxy_pass         http://cloudify-monitoring;
     proxy_redirect     off;
 
@@ -28,6 +27,12 @@ location /monitoring {
     gzip_types application/json;
     gzip_min_length 1000;
     gzip_proxied any;
+
+    error_page 401 = @monitoring-auth-redirect;
+}
+
+location @monitoring-auth-redirect {
+    return 307 /console/login?redirect=/monitoring;
 }
 
 location /monitoring-auth {


### PR DESCRIPTION
On a 401, redirect to stage login. Nicer than the browser http basic auth popup.