### PR TITLE
RD-6802 rabbitmq: disable consumer_timeout

### DIFF
--- a/cfy_manager/components/rabbitmq/config/rabbitmq.config
+++ b/cfy_manager/components/rabbitmq/config/rabbitmq.config
@@ -1,6 +1,7 @@
 [
  {ssl, [{versions, ['tlsv1.2', 'tlsv1.1']}]},
  {rabbit, [
+           {consumer_timeout, undefined},
            {heartbeat, 0},  % clients can override this
            {loopback_users, []},
            {ssl_listeners, [5671]},


### PR DESCRIPTION
This ports #1465 to 6.4.2

Rabbitmq 3.8.15 enables consumer_timeout by default, which means unacked tasks will be rescheduled after 15 (up to 3.8.17) or 30 (later) minutes.

This breaks mgmtworker workflows/operations, which are late-acked.

In order to get pre-3.8.15 behaviour (and note, Cloudify up to 6.4.0 was using rabbitmq 3.8.4), disable this timeout.