### PR TITLE
RD-6807: wait-for-starter: allow systemd service

### DIFF
--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -1344,7 +1344,7 @@ def _has_systemd_starter_service():
     for line in unit_details:
         name, _, value = line.strip().partition(b'=')
         if name == b'LoadState':
-            return value != 'not-found'
+            return value != b'not-found'
     return False
 
 

--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -1374,7 +1374,6 @@ def _is_systemd_starter_service_finished():
 
 def _choose_starter_service_poller(deadline):
     while time.time() < deadline:
-
         if _has_supervisord_starter_service():
             return _is_supervisord_service_finished
         elif _has_systemd_starter_service():
@@ -1396,7 +1395,7 @@ def wait_for_starter(timeout=600, config_file=None):
     _follow = _FileFollow('/var/log/cloudify/manager/cfy_manager.log')
     _follow.seek_to_end()
 
-    is_started = _choose_starter_service_poller()
+    is_started = _choose_starter_service_poller(deadline)
     while time.time() < deadline:
         _follow.poll()
         if is_started():


### PR DESCRIPTION
Also wait for the systemd starter service too. We don't support systemd ourselves, but some deployments (eg. the AMI) might want to implement their starter service as a systemd unit still.