### PR TITLE
RD-6807 wait-for-starter: allow systemd service

### DIFF
--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -1292,7 +1292,7 @@ class _FileFollow(object):
 def _has_supervisord_starter_service():
     try:
         return _get_starter_service_response()
-    except BootstrapError:
+    except (BootstrapError, OSError):
         return False
 
 
@@ -1302,7 +1302,7 @@ def _has_systemd_starter_service():
             ['/bin/systemctl', 'show', f'{STARTER_SERVICE}.service'],
             stderr=subprocess.STDOUT
         ).splitlines()
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, OSError):
         return False
     for line in unit_details:
         name, _, value = line.strip().partition(b'=')
@@ -1317,7 +1317,7 @@ def _is_systemd_starter_service_finished():
             ['/bin/systemctl', 'show', f'{STARTER_SERVICE}.service'],
             stderr=subprocess.STDOUT
         ).splitlines()
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, OSError):
         # systemd is not ready yet
         return False
     for line in unit_details:

--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -1216,30 +1216,6 @@ def upgrade(verbose=False, private_ip=None, public_ip=None, config_file=None):
         component.start()
 
 
-def _is_unit_finished(unit_name='cloudify-starter.service'):
-    try:
-        unit_details = subprocess.check_output(
-            ['/bin/systemctl', 'show', unit_name],
-            stderr=subprocess.STDOUT
-        ).splitlines()
-    except subprocess.CalledProcessError:
-        # systemd is not ready yet
-        return False
-    for line in unit_details:
-        name, _, value = line.strip().partition(b'=')
-        if name == b'ExecMainExitTimestampMonotonic':
-            rv = int(value) > 0
-        if name == b'ExecMainStatus':
-            try:
-                value = int(value)
-            except ValueError:
-                continue
-            if value > 0:
-                raise BootstrapError(
-                    'Starter service exited with code {0}'.format(value))
-    return rv
-
-
 def _get_starter_service_response():
     server = xmlrpclib.Server(
         'http://',
@@ -1313,17 +1289,75 @@ class _FileFollow(object):
             pass
 
 
+def _has_supervisord_starter_service():
+    try:
+        return _get_starter_service_response()
+    except BootstrapError:
+        return False
+
+
+def _has_systemd_starter_service():
+    try:
+        unit_details = subprocess.check_output(
+            ['/bin/systemctl', 'show', f'{STARTER_SERVICE}.service'],
+            stderr=subprocess.STDOUT
+        ).splitlines()
+    except subprocess.CalledProcessError:
+        return False
+    for line in unit_details:
+        name, _, value = line.strip().partition(b'=')
+        if name == b'LoadState':
+            return value != b'not-found'
+    return False
+
+
+def _is_systemd_starter_service_finished():
+    try:
+        unit_details = subprocess.check_output(
+            ['/bin/systemctl', 'show', f'{STARTER_SERVICE}.service'],
+            stderr=subprocess.STDOUT
+        ).splitlines()
+    except subprocess.CalledProcessError:
+        # systemd is not ready yet
+        return False
+    for line in unit_details:
+        name, _, value = line.strip().partition(b'=')
+        if name == b'ExecMainExitTimestampMonotonic':
+            rv = int(value) > 0
+        if name == b'ExecMainStatus':
+            try:
+                value = int(value)
+            except ValueError:
+                continue
+            if value > 0:
+                raise BootstrapError(
+                    'Starter service exited with code {0}'.format(value))
+    return rv
+
+
+def _choose_starter_service_poller(deadline):
+    while time.time() < deadline:
+        if _has_supervisord_starter_service():
+            return _is_supervisord_service_finished
+        elif _has_systemd_starter_service():
+            return _is_systemd_starter_service_finished
+        time.sleep(0.5)
+    raise BootstrapError(
+        'Neither a supervisord starter service, nor a systemd starter '
+        'service exists'
+    )
+
+
 @argh.decorators.named('wait-for-starter')
 @config_arg
 def wait_for_starter(timeout=600, config_file=None):
     config.load_config(config_file)
+    deadline = time.time() + timeout
 
     _follow = _FileFollow('/var/log/cloudify/manager/cfy_manager.log')
     _follow.seek_to_end()
 
-    is_started = _is_supervisord_service_finished \
-        if is_supervisord_service() else _is_unit_finished
-    deadline = time.time() + timeout
+    is_started = _choose_starter_service_poller(deadline)
     while time.time() < deadline:
         _follow.poll()
         if is_started():

--- a/jenkins/bp/ec2-manager-install-blueprint.yaml
+++ b/jenkins/bp/ec2-manager-install-blueprint.yaml
@@ -3,7 +3,7 @@ tosca_definitions_version: cloudify_dsl_1_3
 description: >
   This blueprint deploy EC2 for cloudify-manager-install
 imports:
-  - http://cloudify.co/spec/cloudify/6.4.2/types.yaml
+  - http://cloudify.co/spec/cloudify/6.3.0/types.yaml
   - plugin:cloudify-aws-plugin?version= >=3.0.3
   - plugin:cloudify-utilities-plugin?version= >=1.22.1
 


### PR DESCRIPTION
This ports #1467 to 6.4.2

Some changes were necessary: 6.4.2 does still support using systemd, instead of supervisord.
Thankfully, `_choose_starter_service_poller` will look at both anyway.