### PR TITLE
RD-7044 Move db migration to cloudify-manager-install

### DIFF
--- a/cfy_manager/components/restservice/db.py
+++ b/cfy_manager/components/restservice/db.py
@@ -113,9 +113,8 @@ def run_db_migration():
                cwd='/opt/manager/resources/cloudify/migrations')
     current_db = common.run(
         ['/opt/manager/env/bin/alembic', 'current'],
-        stdout=-1,
-        cwd='/opt/manager/resources/cloudify/migrations',
-    ).stdout
+        cwd='/opt/manager/resources/cloudify/migrations'
+    ).aggr_stdout.strip()
     logger.notice(f'DB successfully migrated to schema revision: {current_db}')
 
 

--- a/cfy_manager/components/restservice/db.py
+++ b/cfy_manager/components/restservice/db.py
@@ -107,6 +107,18 @@ def _create_database(db_name, user):
         'server_db_name', logger)
 
 
+def run_db_migration():
+    logger.notice('Running DB migrations...')
+    common.run(['/opt/manager/env/bin/alembic', 'upgrade', 'head'],
+               cwd='/opt/manager/resources/cloudify/migrations')
+    current_db = common.run(
+        ['/opt/manager/env/bin/alembic', 'current'],
+        stdout=-1,
+        cwd='/opt/manager/resources/cloudify/migrations',
+    ).stdout
+    logger.notice(f'DB successfully migrated to schema revision: {current_db}')
+
+
 def get_provider_context():
     context = {'cloudify': config[PROVIDER_CONTEXT]}
     context['cloudify']['cloudify_agent'] = config[AGENT]

--- a/cfy_manager/components/restservice/restservice.py
+++ b/cfy_manager/components/restservice/restservice.py
@@ -577,6 +577,7 @@ class RestService(BaseComponent):
         self._validate_config_defaults()
         super().upgrade()
         self._deploy_restservice_files()
+        db.run_db_migration()
         run_script_on_manager_venv('/opt/manager/scripts/load_permissions.py')
         run_script_on_manager_venv(
             '/opt/manager/scripts/create_system_filters.py')


### PR DESCRIPTION
Instead of relying on RPM scriptlets, let's execute alembic migration in cloudify-manager-install restservice upgrade procedure.