### PR TITLE
RD-7056 Refactor generating internal/external certs

### DIFF
--- a/cfy_manager/components/nginx/nginx.py
+++ b/cfy_manager/components/nginx/nginx.py
@@ -76,8 +76,8 @@ class Nginx(BaseComponent):
         certificates.generate_external_ssl_cert(
             ips=[external_rest_host, internal_rest_host],
             cn=hostname,
-            sign_cert=ca_cert,
-            sign_key=ca_key,
+            sign_cert_path=ca_cert,
+            sign_key_path=ca_key,
             sign_key_password=key_password,
         )
         certificates.store_cert_metadata(

--- a/cfy_manager/components/prometheus/prometheus.py
+++ b/cfy_manager/components/prometheus/prometheus.py
@@ -253,8 +253,8 @@ def _generate_certs():
         cn=hostname,
         cert_path=config[PROMETHEUS]['cert_path'],
         key_path=config[PROMETHEUS]['key_path'],
-        sign_cert=sign_cert,
-        sign_key=sign_key,
+        sign_cert_path=sign_cert,
+        sign_key_path=sign_key,
     )
     if has_ca_key:
         common.copy(constants.CA_CERT_PATH, constants.MONITORING_CA_CERT_PATH)

--- a/cfy_manager/components/rabbitmq/rabbitmq.py
+++ b/cfy_manager/components/rabbitmq/rabbitmq.py
@@ -471,8 +471,8 @@ class RabbitMQ(BaseComponent):
             cn=rabbit_host,
             cert_path=config[RABBITMQ]['cert_path'],
             key_path=config[RABBITMQ]['key_path'],
-            sign_cert=sign_cert,
-            sign_key=sign_key,
+            sign_cert_path=sign_cert,
+            sign_key_path=sign_key,
             owner='rabbitmq',
             group='rabbitmq',
         )

--- a/cfy_manager/components/validations.py
+++ b/cfy_manager/components/validations.py
@@ -40,6 +40,7 @@ from ..utils.certificates import (
     check_certificates,
     check_ssl_file,
     get_cert_cn,
+    is_signed_by,
 )
 from ..utils.network import is_ipv6
 
@@ -320,9 +321,7 @@ def _validate_ssl_and_external_certificates_match():
 
 
 def _is_cert_self_signed(cert_file):
-    result = run(['openssl', 'verify', '-CAfile', cert_file, cert_file],
-                 ignore_failures=True)
-    return result.returncode == 0
+    return is_signed_by(cert_file, cert_file)
 
 
 def _validate_external_ssl_cert_and_ca():

--- a/cfy_manager/tests/test_certificates.py
+++ b/cfy_manager/tests/test_certificates.py
@@ -251,3 +251,17 @@ def test_check_cert_key_match(tmpdir, ca_cert):
             ca_cert.key_path,
             password=ca_cert.key_password,
         )
+
+
+def test_certs_identical(tmpdir, ca_cert):
+    other_cert_path, _ = certificates._generate_ssl_certificate(
+        ips=['127.0.0.1'],
+        cn='localhost',
+        cert_path=tmpdir / 'cert.pem',
+        key_path=tmpdir / 'key.pem',
+        owner=os.geteuid(),
+        group=os.getegid(),
+    )
+
+    assert certificates.certs_identical(ca_cert.cert_path, ca_cert.cert_path)
+    assert not certificates.certs_identical(ca_cert.cert_path, other_cert_path)

--- a/cfy_manager/tests/test_certificates.py
+++ b/cfy_manager/tests/test_certificates.py
@@ -3,6 +3,7 @@ import os
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 
+import mock
 import pytest
 
 from cryptography import x509
@@ -10,6 +11,17 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
 
 from cfy_manager.utils import certificates
+
+
+@pytest.fixture(autouse=True)
+def _mock_small_cert_size():
+    """Mock CERT_SIZE to a small value.
+
+    In tests, we don't need to create large certs. Making the size small
+    makes these tests faster by an order of magnitude.
+    """
+    with mock.patch('cfy_manager.utils.certificates.CERT_SIZE', 512):
+        yield
 
 
 def test_generate_self_signed_cert(tmpdir):

--- a/cfy_manager/tests/test_certificates.py
+++ b/cfy_manager/tests/test_certificates.py
@@ -196,7 +196,7 @@ def test_check_signed_by_true(tmpdir, ca_cert):
         group=os.getegid(),
     )
 
-    certificates._check_signed_by(ca_cert.cert_path, cert_path)  # doesnt throw
+    assert certificates.is_signed_by(ca_cert.cert_path, cert_path)
 
 
 def test_check_signed_by_false(tmpdir, ca_cert):
@@ -210,8 +210,7 @@ def test_check_signed_by_false(tmpdir, ca_cert):
         group=os.getegid(),
     )
 
-    with pytest.raises(ValidationError):
-        certificates._check_signed_by(ca_cert.cert_path, cert_path)
+    assert not certificates.is_signed_by(ca_cert.cert_path, cert_path)
 
 
 def test_get_cert_cn(tmpdir, ca_cert):

--- a/cfy_manager/tests/test_certificates.py
+++ b/cfy_manager/tests/test_certificates.py
@@ -2,8 +2,8 @@ import ipaddress
 import os
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from unittest import mock
 
-import mock
 import pytest
 
 from cryptography import x509

--- a/cfy_manager/tests/test_certificates.py
+++ b/cfy_manager/tests/test_certificates.py
@@ -1,0 +1,127 @@
+import ipaddress
+import os
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+import pytest
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+
+from cfy_manager.utils import certificates
+
+
+def test_generate_self_signed_cert(tmpdir):
+    cert_path, key_path = certificates._generate_ssl_certificate(
+        ips=['127.0.0.1', '192.168.2.4'],
+        cn='localhost',
+        cert_path=tmpdir / 'cert.pem',
+        key_path=tmpdir / 'key.pem',
+        owner=os.geteuid(),
+        group=os.getegid(),
+    )
+
+    with open(cert_path, 'rb') as cert_file:
+        cert = x509.load_pem_x509_certificate(cert_file.read())
+    with open(key_path, 'rb') as key_file:
+        key = serialization.load_pem_private_key(
+            key_file.read(), password=None)
+        pubkey = key.public_key()
+
+    # check SANs; both the ips and the CN must be there
+    sans = cert.extensions.get_extension_for_class(x509.SubjectAlternativeName)
+    assert x509.DNSName('localhost') in sans.value
+    assert x509.IPAddress(ipaddress.ip_address('127.0.0.1')) in sans.value
+    assert x509.IPAddress(ipaddress.ip_address('192.168.2.4')) in sans.value
+    # we also add IPs as DNSname onto the cert, because that's what some
+    # browsers want
+    assert x509.DNSName('127.0.0.1') in sans.value
+    assert x509.DNSName('192.168.2.4') in sans.value
+
+    # check that the cert is actually self-signed - signed by the returned key
+    pubkey.verify(
+        cert.signature,
+        cert.tbs_certificate_bytes,
+        padding.PKCS1v15(),
+        cert.signature_hash_algorithm,
+    )
+
+
+@dataclass
+class _TestCACert:
+    cert: x509.Certificate
+    key: rsa.RSAPrivateKey
+    key_path: str
+    cert_path: str
+    key_password: str
+
+
+@pytest.fixture
+def ca_cert(tmpdir):
+    key_path = tmpdir / 'ca_key.pem'
+    cert_path = tmpdir / 'ca_cert.pem'
+
+    key = rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=512,  # no need for a big key in tests
+    )
+    key_password = 'key_password1'
+
+    key_pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=(
+            serialization.BestAvailableEncryption(key_password.encode())
+        ),
+    )
+    with open(key_path, 'wb') as key_file:
+        key_file.write(key_pem)
+
+    name = x509.Name([
+        x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, 'test'),
+    ])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.utcnow())
+        .not_valid_after(datetime.utcnow() + timedelta(days=1))
+        .sign(key, hashes.SHA256())
+    )
+    with open(cert_path, 'wb') as cert_file:
+        cert_file.write(cert.public_bytes(serialization.Encoding.PEM))
+
+    return _TestCACert(
+        cert=cert,
+        key=key,
+        key_path=key_path,
+        cert_path=cert_path,
+        key_password=key_password,
+    )
+
+
+def test_generate_signed_cert(tmpdir, ca_cert):
+    cert_path, _ = certificates._generate_ssl_certificate(
+        ips=['127.0.0.1'],
+        cn='localhost',
+        cert_path=tmpdir / 'cert.pem',
+        key_path=tmpdir / 'key.pem',
+        sign_cert=ca_cert.cert_path,
+        sign_key=ca_cert.key_path,
+        sign_key_password=ca_cert.key_password,
+        owner=os.geteuid(),
+        group=os.getegid(),
+    )
+
+    with open(cert_path, 'rb') as cert_file:
+        cert = x509.load_pem_x509_certificate(cert_file.read())
+
+    ca_cert.key.public_key().verify(
+        cert.signature,
+        cert.tbs_certificate_bytes,
+        padding.PKCS1v15(),
+        cert.signature_hash_algorithm,
+    )

--- a/cfy_manager/tests/test_certificates.py
+++ b/cfy_manager/tests/test_certificates.py
@@ -265,3 +265,18 @@ def test_certs_identical(tmpdir, ca_cert):
 
     assert certificates.certs_identical(ca_cert.cert_path, ca_cert.cert_path)
     assert not certificates.certs_identical(ca_cert.cert_path, other_cert_path)
+
+
+def test_check_ssl_file(tmpdir, ca_cert):
+    with pytest.raises(ValidationError):
+        certificates.check_ssl_file(tmpdir / 'nonexistent')
+
+    with pytest.raises(ValidationError):
+        certificates.check_ssl_file(ca_cert.cert_path, kind='Key')
+
+    with pytest.raises(ValidationError):
+        certificates.check_ssl_file(ca_cert.key_path, kind='Cert')
+
+    certificates.check_ssl_file(ca_cert.key_path, kind='Key',
+                                password=ca_cert.key_password)
+    certificates.check_ssl_file(ca_cert.cert_path, kind='Cert')

--- a/cfy_manager/tests/test_certificates.py
+++ b/cfy_manager/tests/test_certificates.py
@@ -212,3 +212,8 @@ def test_check_signed_by_false(tmpdir, ca_cert):
 
     with pytest.raises(ValidationError):
         certificates._check_signed_by(ca_cert.cert_path, cert_path)
+
+
+def test_get_cert_cn(tmpdir, ca_cert):
+    cn = certificates.get_cert_cn(ca_cert.cert_path)
+    assert cn == 'test'

--- a/cfy_manager/tests/test_certificates.py
+++ b/cfy_manager/tests/test_certificates.py
@@ -109,8 +109,8 @@ def test_generate_signed_cert(tmpdir, ca_cert):
         cn='localhost',
         cert_path=tmpdir / 'cert.pem',
         key_path=tmpdir / 'key.pem',
-        sign_cert=ca_cert.cert_path,
-        sign_key=ca_cert.key_path,
+        sign_cert_path=ca_cert.cert_path,
+        sign_key_path=ca_cert.key_path,
         sign_key_password=ca_cert.key_password,
         owner=os.geteuid(),
         group=os.getegid(),
@@ -125,3 +125,9 @@ def test_generate_signed_cert(tmpdir, ca_cert):
         padding.PKCS1v15(),
         cert.signature_hash_algorithm,
     )
+
+    # check issuer name - it should be the signing cert's CN, not our own
+    issuer_cn_oid = cert.issuer.get_attributes_for_oid(
+        x509.oid.NameOID.COMMON_NAME)
+    assert len(issuer_cn_oid) == 1
+    assert issuer_cn_oid[0].value == 'test'

--- a/cfy_manager/utils/certificates.py
+++ b/cfy_manager/utils/certificates.py
@@ -232,8 +232,8 @@ def _generate_ssl_certificate(
     cn: str,
     cert_path: str | Path,
     key_path: str | Path,
-    sign_cert: str | Path = None,
-    sign_key: str | Path = None,
+    sign_cert_path: str | Path = None,
+    sign_key_path: str | Path = None,
     sign_key_password: str = None,
     key_perms: int = 0o440,
     cert_perms: int = 0o444,
@@ -333,21 +333,26 @@ def generate_internal_ssl_cert(ips, cn):
         cn,
         const.INTERNAL_CERT_PATH,
         const.INTERNAL_KEY_PATH,
-        sign_cert=const.CA_CERT_PATH,
-        sign_key=const.CA_KEY_PATH
+        sign_cert_path=const.CA_CERT_PATH,
+        sign_key_path=const.CA_KEY_PATH
     )
     return cert_path, key_path
 
 
-def generate_external_ssl_cert(ips, cn, sign_cert=None, sign_key=None,
-                               sign_key_password=None):
+def generate_external_ssl_cert(
+    ips,
+    cn,
+    sign_cert_path=None,
+    sign_key_path=None,
+    sign_key_password=None,
+):
     return _generate_ssl_certificate(
         ips,
         cn,
         const.EXTERNAL_CERT_PATH,
         const.EXTERNAL_KEY_PATH,
-        sign_cert=sign_cert,
-        sign_key=sign_key,
+        sign_cert_path=sign_cert_path,
+        sign_key_path=sign_key_path,
         sign_key_password=sign_key_password
     )
 
@@ -416,8 +421,8 @@ def create_internal_certs(manager_hostname=None,
             # We only support ipsetter on nodes with managers, so the fact
             # that this would break if used on a node containing only rmq
             # doesn't matter
-            sign_cert=const.CA_CERT_PATH,
-            sign_key=const.CA_KEY_PATH,
+            sign_cert_path=const.CA_CERT_PATH,
+            sign_key_path=const.CA_KEY_PATH,
         )
 
     store_cert_metadata(
@@ -458,8 +463,8 @@ def create_external_certs(private_ip=None,
         cn=public_ip,
         cert_path=const.EXTERNAL_CERT_PATH,
         key_path=const.EXTERNAL_KEY_PATH,
-        sign_cert=sign_cert,
-        sign_key=sign_key,
+        sign_cert_path=sign_cert,
+        sign_key_path=sign_key,
         sign_key_password=sign_key_password
     )
 

--- a/cfy_manager/utils/certificates.py
+++ b/cfy_manager/utils/certificates.py
@@ -596,9 +596,14 @@ def get_ca_filename(new_ca_location, default_ca_location):
 
 
 def certs_identical(cert_a, cert_b):
-    content_a = run(['openssl', 'x509', '-noout', '-modulus', '-in', cert_a])
-    content_b = run(['openssl', 'x509', '-noout', '-modulus', '-in', cert_b])
-    return content_a.aggr_stdout == content_b.aggr_stdout
+    with open(cert_a, 'rb') as cert_a_file:
+        cert_a = x509.load_pem_x509_certificate(cert_a_file.read())
+    with open(cert_b, 'rb') as cert_b_file:
+        cert_b = x509.load_pem_x509_certificate(cert_b_file.read())
+
+    cert_a_modulus = cert_a.public_key().public_numbers().n
+    cert_b_modulus = cert_b.public_key().public_numbers().n
+    return cert_a_modulus == cert_b_modulus
 
 
 def clean_certs():

--- a/cfy_manager/utils/certificates.py
+++ b/cfy_manager/utils/certificates.py
@@ -332,12 +332,18 @@ def generate_ca_cert(cert_path=const.CA_CERT_PATH,
 def remove_key_encryption(src_key_path,
                           dst_key_path,
                           key_password):
-    run([
-        'openssl', 'rsa',
-        '-in', src_key_path,
-        '-out', dst_key_path,
-        '-passin', u'pass:{0}'.format(key_password).encode('utf-8')
-    ])
+    with open(src_key_path, 'rb') as key_file:
+        key = serialization.load_pem_private_key(
+            key_file.read(),
+            password=key_password.encode(),
+        )
+    with open(dst_key_path, 'wb') as key_file:
+        key_pem = key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        key_file.write(key_pem)
 
 
 @argh.arg('--metadata',

--- a/cfy_manager/utils/certificates.py
+++ b/cfy_manager/utils/certificates.py
@@ -34,6 +34,9 @@ from cfy_manager.exceptions import ValidationError
 logger = get_logger('Certificates')
 
 
+CERT_SIZE = 4096
+
+
 def get_cert_cn(cert_path):
     raw = run(
         ['openssl', 'x509', '-noout', '-subject', '-in', cert_path]
@@ -225,7 +228,7 @@ def _generate_ssl_certificate(
 
     key = rsa.generate_private_key(
         public_exponent=65537,
-        key_size=4096,
+        key_size=CERT_SIZE,
     )
     subject = issuer = x509.Name([
         x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, cn),

--- a/cfy_manager/utils/certificates.py
+++ b/cfy_manager/utils/certificates.py
@@ -208,7 +208,9 @@ def _generate_ssl_certificate(
         with open(sign_key_path, 'rb') as sign_key_file:
             sign_key = serialization.load_pem_private_key(
                 sign_key_file.read(),
-                password=sign_key_password.encode(),
+                password=(
+                    sign_key_password.encode() if sign_key_password else None
+                ),
             )
         with open(sign_cert_path, 'rb') as sign_cert_file:
             sign_cert = x509.load_pem_x509_certificate(sign_cert_file.read())

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -72,6 +72,18 @@ pipeline {
             }
           }
         }
+        stage('tests') {
+          steps{
+            container('py311'){
+              dir("${env.WORKSPACE}/${env.PROJECT}") {
+                sh 'pip install pip setuptools --upgrade'
+                sh 'pip install pytest --user'
+                sh 'pip install . --user'
+                sh 'pytest -svx cfy_manager'
+              }
+            }
+          }
+        }
         stage('fetch_rpms') {
           steps {
             sh script:"mkdir -p ${env.WORKSPACE}/rpms", label: "creating RPMs folder"

--- a/jenkins/cluster/start_cluster.sh
+++ b/jenkins/cluster/start_cluster.sh
@@ -29,6 +29,7 @@ function create_certs(){
   pushd ${TMPDIR}
     generate_certs
   popd
+  openssl rsa -aes256 -passout pass:secret_ca_password -in ${TMPDIR}/ca.key -out ${TMPDIR}/ca.encrypted.key
 }
 
 function run_queue1(){
@@ -142,7 +143,6 @@ function run_manager1(){
       manager1_config.yaml > ${TMPDIR}/rendered_manager1_config.yaml
   cat ${TMPDIR}/rendered_manager1_config.yaml
     # Generate ca encrypted key
-  openssl rsa -aes256 -passout pass:secret_ca_password -in ${TMPDIR}/ca.key -out ${TMPDIR}/ca.encrypted.key
   sudo docker cp ${TMPDIR}/rendered_manager1_config.yaml ${NODE1_NAME}:/etc/cloudify/manager_config.yaml
   sudo docker cp ${TMPDIR}/manager_1_key.pem ${NODE1_NAME}:/etc/cloudify/manager_key.pem
   sudo docker cp ${TMPDIR}/manager_1_cert.pem ${NODE1_NAME}:/etc/cloudify/manager_cert.pem

--- a/setup.py
+++ b/setup.py
@@ -56,11 +56,13 @@ setup(
         'jinja2>3,<4',
         'argh==0.26.2',
         'netifaces==0.10.9',
-        'ipaddress==1.0.23',
         'psutil==5.7.2',
         'requests>=2.18,<3.0.0',
         'retrying==1.3.3',
+        'cryptography>39,<40',
+        'distro',    # replacing deprecated platform.linux_distribution
+        # supervisor is not used in this package directly, but it is
+        # installed here to provide the `supervisord` executable
         'supervisor==4.2.2',
-        'distro'    # replacing deprecated platform.linux_distribution
     ]
 )


### PR DESCRIPTION
Rewrite the cert-related functions to use cryptography rather than subprocess openssl.

Also add some tests around the cert handling functions.

This doesn't cause any behaviour changes by itself, but will make it MUCH easier to work with certs.

In the commits, I'm going to be essentially rewriting every `openssl`-calling function one by one, to use cryptography instead.