### PR TITLE
RD-7056 Include public_ip on the internal cert

### DIFF
--- a/cfy_manager/components/nginx/config/manager.upstream
+++ b/cfy_manager/components/nginx/config/manager.upstream
@@ -13,54 +13,18 @@ upstream cloudify-rest {
   server 127.0.0.1:{{ restservice.port }};
 }
 
-{% set internal_rest_ports = [manager.internal_rest_port] + manager.additional_internal_rest_listeners %}
-{% set external_rest_port = nginx.port or 443 %}
-{#
-  we only have a separate external ssl listener, when the same addr + port
-  is not already an _internal_ ssl listener.
-  If the internal and external listeners would be the same, then only the
-  internal listener will exist.
-#}
-{% set has_external_ssl_listener =
-  (manager.public_ip != manager.private_ip) or (external_rest_port not in internal_rest_ports)
-%}
-
-{%- if manager.external_rest_protocol == 'http' -%}
-# REST and UI server.
+{% for listener in nginx.listeners -%}
 server {
-  # server listening
-  listen              *:{{ nginx.port | default('80', true) }};
+  listen              {{ listener.port }} {% if listener.ssl %}ssl http2{% endif %};
   {% if ipv6_enabled -%}
-  listen              [::]:{{ nginx.port | default('80', true) }};
+  listen              [::]:{{ listener.port }} {% if listener.ssl %}ssl http2{% endif %};
   {%- endif %}
-  server_name         _;
+  server_name         {{ listener.server_name }};
 
-  include "/etc/nginx/conf.d/logs-conf.cloudify";
-
-  # serve the UI
-  include "/etc/nginx/conf.d/ui-locations.cloudify";
-
-  # serve the Composer
-  include "/etc/nginx/conf.d/composer-location.cloudify";
-
-  # Serves the Rest Service (backed by the cloudify-rest upstream).
-  include "/etc/nginx/conf.d/rest-location.cloudify";
-
-  # Serves the File Server and proxy for the Cloudify-API.
-  include "/etc/nginx/conf.d/authd-location.cloudify";
-}
-{%- elif has_external_ssl_listener -%}
-# REST and UI external server
-server {
-  # server listening for external requests
-  listen              {{ external_rest_port }} ssl http2;
-  {% if ipv6_enabled -%}
-  listen              [::]:{{ external_rest_port }} ssl http2;
-  {%- endif %}
-  server_name         {{ manager.public_ip }};
-
-  ssl_certificate     {{ constants.EXTERNAL_CERT_PATH }};
-  ssl_certificate_key {{ constants.EXTERNAL_KEY_PATH }};
+  {% if listener.ssl %}
+  ssl_certificate     {{ listener.cert_path }};
+  ssl_certificate_key {{ listener.key_path }};
+  {% endif %}
 
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
@@ -78,12 +42,9 @@ server {
   # Serves the File Server and proxy for the Cloudify-API.
   include "/etc/nginx/conf.d/authd-location.cloudify";
 }
+{% endfor %}
 
-{#
-  if port is set by the user, then it is non-standard and not 443, so
-  let's skip the standard 80 port as well
-#}
-{% if nginx.port is none %}
+{% if nginx.nonssl_access_blocked %}
 server {
   listen 80;
   {% if ipv6_enabled -%}
@@ -105,30 +66,3 @@ server {
   }
 }
 {% endif %}
-{%- endif -%}
-
-{% for internal_port in internal_rest_ports %}
-# REST and UI internal server - always SSL enabled
-server {
-  # server listening for internal requests
-  listen              {{ internal_port }} ssl default_server http2;
-  {% if ipv6_enabled -%}
-  listen              [::]:{{ internal_port }} ssl default_server http2;
-  {%- endif %}
-
-  server_name         _;
-
-  ssl_certificate     {{ constants.INTERNAL_CERT_PATH }};
-  ssl_certificate_key {{ constants.INTERNAL_KEY_PATH }};
-
-  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-
-  include "/etc/nginx/conf.d/logs-conf.cloudify";
-{% if 'manager_service' in services_to_install %}
-  # Serves the Rest Service (backed by the cloudify-rest upstream).
-  include "/etc/nginx/conf.d/rest-location.cloudify";
-
-  # Serves the File Server and proxy for the Cloudify-API.
-  include "/etc/nginx/conf.d/authd-location.cloudify";{% endif %}
-}
-{% endfor %}

--- a/cfy_manager/components/nginx/nginx.py
+++ b/cfy_manager/components/nginx/nginx.py
@@ -47,14 +47,15 @@ class Nginx(BaseComponent):
         logger.info('Generating internal certificate...')
         networks = config['networks']
         hostname = config[MANAGER][HOSTNAME]
+        addresses = list(networks.values()) + [config[MANAGER][PUBLIC_IP]]
         certificates.store_cert_metadata(
             hostname,
-            new_managers=list(networks.values()),
+            new_managers=addresses,
             new_networks=list(networks.keys()),
         )
 
         certificates.generate_internal_ssl_cert(
-            ips=list(networks.values()),
+            ips=addresses,
             cn=hostname
         )
 

--- a/cfy_manager/components/prometheus/prometheus.py
+++ b/cfy_manager/components/prometheus/prometheus.py
@@ -460,8 +460,10 @@ def _update_manager_targets(private_ip, cluster_config, uninstalling):
         # Monitor stage directly and via nginx
         http_200_targets.append('http://127.0.0.1:8088')
         # Monitor cloudify's internal port
-        http_200_targets.append('https://{}:53333/api/v3.1/ok'
-                                .format(private_ip))
+        internal_rest_port = config[MANAGER]['internal_rest_port']
+        http_200_targets.append(
+            f'https://{private_ip}:{internal_rest_port}/api/v3.1/ok'
+        )
         # Monitor cloudify restservice
         http_200_targets.append('http://127.0.0.1:8100/api/v3.1/ok')
         # Monitor cloudify-api's openapi.json

--- a/cfy_manager/components/validations.py
+++ b/cfy_manager/components/validations.py
@@ -410,7 +410,7 @@ def _check_internal_cert_sans():
             expected = x509.IPAddress(parsed_ip)
         else:
             expected = x509.DNSName(expected_addr)
-        if not expected in internal_sans:
+        if expected not in internal_sans:
             missing_addrs.append(expected_addr)
     if missing_addrs:
         raise ValidationError(

--- a/cfy_manager/main.py
+++ b/cfy_manager/main.py
@@ -865,6 +865,7 @@ def validate_command(verbose=False,
         config_file=config_file,
     )
     components = _get_components()
+    set_globals()
     validate(components=components)
     validate_dependencies(components=components)
 
@@ -1027,6 +1028,7 @@ def configure(verbose=False,
     _validate_components_prepared('configure', config_file)
     logger.notice('Configuring desired components...')
     components = _get_components()
+    set_globals()
     validate(components=components)
     set_globals()
 
@@ -1208,6 +1210,7 @@ def upgrade(verbose=False, private_ip=None, public_ip=None, config_file=None):
     config[UPGRADE_IN_PROGRESS] = True
     _validate_components_prepared('restart', config_file)
     components = _get_components()
+    set_globals()
     validate(components=components, only_install=False)
     upgrade_components = _get_components()
     packages_to_update, _ = _get_packages()

--- a/cfy_manager/tests/test_certificates.py
+++ b/cfy_manager/tests/test_certificates.py
@@ -307,3 +307,24 @@ def test_remove_key_encryption(tmpdir, ca_cert):
             key_file.read(),
             password=None,
         )
+
+
+def test_get_cert_sans(tmpdir, ca_cert):
+    cert_path, _ = certificates._generate_ssl_certificate(
+        ips=['192.168.2.4', 'example.com'],
+        cn='localhost',
+        cert_path=tmpdir / 'cert.pem',
+        key_path=tmpdir / 'key.pem',
+        sign_cert_path=ca_cert.cert_path,
+        sign_key_path=ca_cert.key_path,
+        sign_key_password=ca_cert.key_password,
+        owner=os.geteuid(),
+        group=os.getegid(),
+    )
+    sans = certificates.get_cert_sans(cert_path)
+    assert set(sans) == {
+        x509.DNSName('localhost'),
+        x509.DNSName('example.com'),
+        x509.DNSName('192.168.2.4'),
+        x509.IPAddress(ipaddress.IPv4Address('192.168.2.4')),
+    }

--- a/cfy_manager/utils/certificates.py
+++ b/cfy_manager/utils/certificates.py
@@ -69,6 +69,16 @@ def get_cert_cn(cert_path):
         return None
 
 
+def get_cert_sans(cert_path):
+    """Return a list of SubjectAlternativeNames on the given cert"""
+    with open(cert_path, 'rb') as cert_file:
+        cert = x509.load_pem_x509_certificate(cert_file.read())
+
+    return cert.extensions.get_extension_for_class(
+        x509.SubjectAlternativeName,
+    ).value
+
+
 def handle_ca_cert(logger, generate_if_missing=True):
     """
     The user might provide both the CA key and the CA cert, or just the


### PR DESCRIPTION
In some cases, the internal cert will be used to host the "public" access as well, so it should include the public ip as well. Also, there's no downside to just putting it on there.

The main thing to note is:
- when public ip is an ip (not a domain name), and we serve https/443 on both "internal" and "external", then we end up using the internal cert for all requests, because SNI only works for domain names, not ips.

And so, let's decide python-side (set_globals) on what exactly should the nginx listeners be, and then use validations to check that the certs are as expected.

This means that with the common auto-generated cert approach, if we enable external ssl, there's only one nginx listener on 443; and if external ssl is disabled, there's one on 80, and one on 443.

...that, plus a whole bunch of conditionals, based on the configured ports.