### PR TITLE
RD-6586 Use the configured port in stage & composer config files

### DIFF
--- a/cfy_manager/components/composer/composer.py
+++ b/cfy_manager/components/composer/composer.py
@@ -128,7 +128,8 @@ class Composer(BaseComponent):
 
         composer_config['managerConfig']['ip'] = \
             ipv6_url_compat(config[MANAGER][PRIVATE_IP])
-
+        composer_config['managerConfig']['port'] = \
+            config[MANAGER]['internal_rest_port']
         certs = {
             'cert': DB_CLIENT_CERT_PATH,
             'key': DB_CLIENT_KEY_PATH,

--- a/cfy_manager/components/stage/stage.py
+++ b/cfy_manager/components/stage/stage.py
@@ -162,6 +162,7 @@ class Stage(BaseComponent):
         stage_config = json.loads(files.read(config_path))
 
         stage_config['ip'] = ipv6_url_compat(config[MANAGER][PRIVATE_IP])
+        stage_config['port'] = config[MANAGER]['internal_rest_port']
         content = json.dumps(stage_config, indent=4, sort_keys=True)
         files.write(contents=content, destination=config_path,
                     owner=STAGE_USER, group=STAGE_GROUP, mode=0o640)


### PR DESCRIPTION
Those json config files contain the internal REST endpoint's port, so they need to be updated with whatever the configured port is (default 443, old-default 53333).