### PR TITLE
RND-206 usage-collector: use direct queries where possible

### DIFF
--- a/cfy_manager/components/usage_collector/scripts/collect_cloudify_uptime.py
+++ b/cfy_manager/components/usage_collector/scripts/collect_cloudify_uptime.py
@@ -1,10 +1,13 @@
-from script_utils import (logger,
-                          send_data,
-                          HOURS_LOCK,
-                          HOURS_INTERVAL,
-                          collect_metadata,
-                          should_send_data,
-                          usage_collector_lock)
+from script_utils import (
+    logger,
+    send_data,
+    HOURS_LOCK,
+    HOURS_INTERVAL,
+    collect_metadata,
+    should_send_data,
+    usage_collector_lock,
+    setup_appctx,
+)
 
 
 CLOUDIFY_ENDPOINT_UPTIME_URL = 'https://api.cloudify.co/cloudifyUptime'
@@ -27,4 +30,5 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    with setup_appctx():
+        main()

--- a/jenkins/bp/ec2-manager-install-blueprint.yaml
+++ b/jenkins/bp/ec2-manager-install-blueprint.yaml
@@ -3,7 +3,7 @@ tosca_definitions_version: cloudify_dsl_1_3
 description: >
   This blueprint deploy EC2 for cloudify-manager-install
 imports:
-  - http://cloudify.co/spec/cloudify/7.1.0.dev1/types.yaml
+  - http://cloudify.co/spec/cloudify/6.3.0/types.yaml
   - plugin:cloudify-aws-plugin?version= >=3.0.3
   - plugin:cloudify-utilities-plugin?version= >=1.22.1
 


### PR DESCRIPTION
Avoid using the storage-manager, where it's not necessary. Specifically, `sm.count()` no longer exists.

Also, just push appctx at the entrypoint, no need for more fine-grained context management than that.