### PR TITLE
RND-495 If public_ip is not a hostname, use internal cert

### DIFF
--- a/cfy_manager/components/globals.py
+++ b/cfy_manager/components/globals.py
@@ -18,7 +18,7 @@ import socket
 from .. import constants
 from ..config import config
 from ..logger import get_logger
-from ..utils.network import ipv6_url_compat
+from ..utils.network import ipv6_url_compat, parse_ip
 
 from ..service_names import (
     MANAGER,
@@ -30,6 +30,7 @@ from ..service_names import (
 from . import DATABASE_SERVICE, MANAGER_SERVICE
 from ..components_constants import (
     PRIVATE_IP,
+    PUBLIC_IP,
     SECURITY,
     SERVICES_TO_INSTALL,
     SSL_ENABLED,
@@ -60,6 +61,7 @@ def _set_external_port_and_protocol():
 
 def _set_ip_config():
     private_ip = config[MANAGER][PRIVATE_IP]
+    public_ip = config[MANAGER][PUBLIC_IP]
 
     config[MANAGER]['file_server_root'] = constants.MANAGER_RESOURCES_HOME
     config[MANAGER]['file_server_url'] = 'https://{0}:{1}/resources'.format(
@@ -69,6 +71,10 @@ def _set_ip_config():
 
     config.setdefault('networks', {})
     config['networks'].setdefault('default', private_ip)
+
+    # ...also add the public ip to networks for easy access by the user,
+    # and so that it's always present on the internal cert
+    config['networks'].setdefault('external', public_ip)
 
 
 def _set_hostname():
@@ -96,31 +102,41 @@ def _set_nginx_listeners():
     if config.get(NGINX, {}).get('listeners'):
         return
 
+    # add the "internal" listener - always ssl, might be multiple ports,
+    # in case the user configured additional "internal" ports
+    internal_ports = {config[MANAGER]['internal_rest_port']}
+    internal_ports.update(
+        config[MANAGER].get('additional_internal_rest_listeners') or []
+    )
+
+    listeners = []
+
     # add the "external" listener, ssl or non-ssl, based on the config
     if config[MANAGER][SECURITY]['ssl_enabled']:
         config[NGINX]['nonssl_access_blocked'] = True
-
-        listeners = [{
-            'port': config[MANAGER]['external_rest_port'],
-            'server_name': config[MANAGER]['public_ip'],
-            'ssl': True,
-            'cert_path': constants.EXTERNAL_CERT_PATH,
-            'key_path': constants.EXTERNAL_KEY_PATH,
-        }]
+        # if the external ip is an IP (not hostname), then we cannot use
+        # a separate certificate, because SNI won't work with IPs;
+        # in that case, just add the public port to the internal
+        # listeners, so it'll be served along with the internal ports
+        if parse_ip(config[MANAGER][PUBLIC_IP]):
+            internal_ports.add(config[MANAGER]['external_rest_port'])
+        else:
+            # this is a hostname, so SNI can work
+            listeners.append({
+                'port': config[MANAGER]['external_rest_port'],
+                'server_name': config[MANAGER][PUBLIC_IP],
+                'ssl': True,
+                'cert_path': constants.EXTERNAL_CERT_PATH,
+                'key_path': constants.EXTERNAL_KEY_PATH,
+            })
     else:
-        listeners = [{
+        listeners.append({
             'port': config[MANAGER]['external_rest_port'],
             'server_name': '_',
             'ssl': False,
-        }]
+        })
 
-    # add the "internal" listener - always ssl, might be multiple ports,
-    # in case the user configured additional "internal" ports
-    internal_ports = [config[MANAGER]['internal_rest_port']]
-    internal_ports.extend(
-        config[MANAGER].get('additional_internal_rest_listeners') or []
-    )
-    for internal_port in internal_ports:
+    for internal_port in set(internal_ports):
         listeners.append({
             'port': internal_port,
             'server_name': '_',

--- a/jenkins/cluster/create_certs.sh
+++ b/jenkins/cluster/create_certs.sh
@@ -1,7 +1,7 @@
 # this script must be sourced from start_cluster.sh
 function generate_test_cert {
     san=$1
-    docker run --rm  -v $(pwd):/root/.cloudify-test-ca ${IMAGE} cfy_manager generate-test-cert -s $san
+    docker run --rm  -v $(pwd):/root/.cloudify-test-ca ${IMAGE} cfy_manager generate-test-cert -s $san,manager.local
 }
 
 function generate_certs(){

--- a/jenkins/cluster/manager1_config.yaml
+++ b/jenkins/cluster/manager1_config.yaml
@@ -1,6 +1,6 @@
 manager:
   private_ip: CONTAINER_IP
-  public_ip: CONTAINER_IP
+  public_ip: manager.local
   hostname: manager1
   security:
     ssl_enabled: true

--- a/jenkins/cluster/manager2_config.yaml
+++ b/jenkins/cluster/manager2_config.yaml
@@ -1,6 +1,6 @@
 manager:
   private_ip: CONTAINER_IP
-  public_ip: CONTAINER_IP
+  public_ip: manager.local
   hostname: manager2
   security:
     ssl_enabled: true

--- a/jenkins/cluster/manager3_config.yaml
+++ b/jenkins/cluster/manager3_config.yaml
@@ -1,6 +1,6 @@
 manager:
   private_ip: CONTAINER_IP
-  public_ip: CONTAINER_IP
+  public_ip: manager.local
   hostname: manager3
   security:
     ssl_enabled: true


### PR DESCRIPTION
This ports #1513 to 7.0.0

* RND-495 If public_ip is not a hostname, use internal cert

SNI doesn't work with IPs, only hostnames/fqdns :)

So we can't have multiple IPs in nginx.conf, and have each use a different cert. Therefore, if public_ip is an ip (not hostname), it will have to cope with being served using the internal cert as well... for the user, it shouldn't make much difference, if it's an auto-generated certificate. But if the user tries to provide their own certificate in that case, it's a validation error, because that'll never work.

Also see comments

* cluster test: use a fqdn for the public ip