### PR TITLE
RND-584 nginx: add request rate-limiting

### DIFF
--- a/cfy_manager/components/nginx/config/manager.upstream
+++ b/cfy_manager/components/nginx/config/manager.upstream
@@ -13,6 +13,17 @@ upstream cloudify-rest {
   server 127.0.0.1:{{ restservice.port }};
 }
 
+
+{% if nginx.rate_limit.enabled %}
+map $http_execution_token $no_token_limit {
+  default $binary_remote_addr;
+  "~.+" "";
+}
+
+limit_req_zone $no_token_limit zone=ratelimit:10m rate={{ nginx.rate_limit.rate }};
+{% endif %}
+
+
 {% for listener in nginx.listeners -%}
 server {
   listen              {{ listener.port }} {% if listener.ssl %}ssl http2{% endif %};
@@ -27,6 +38,10 @@ server {
   {% endif %}
 
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
+  {% if nginx.rate_limit.enabled %}
+  limit_req zone=ratelimit burst={{ nginx.rate_limit.burst }} delay={{ nginx.rate_limit.delay }};
+  {% endif %}
 
   include "/etc/nginx/conf.d/logs-conf.cloudify";
 
@@ -51,6 +66,10 @@ server {
   listen              [::]:80;
   {%- endif %}
   server_name _;
+
+  {% if nginx.rate_limit.enabled %}
+  limit_req zone=ratelimit;
+  {% endif %}
 
   # For REST API requests, return HTTP 400.
   # We don't want to automatically redirect API requests which

--- a/config.yaml
+++ b/config.yaml
@@ -482,6 +482,24 @@ nginx:
   # is allowed to have.
   max_open_fds: 102400
 
+  # configure request rate-limits. If enabled, requests are rate-limited based
+  # on the remote IP address.
+  # Requests that authenticate with a valid execution-token, are never
+  # rate-limited
+  rate_limit:
+    enabled: true
+    # rate is a string in the form of "10r/s" (10 requests per second)
+    # or "600r/m" (600 requests per minute)
+    rate: "10r/s"
+    # burst and delay manage the request queueing mechanism. With the
+    # default settings of burst=30 and delay=20, up to 30 requests
+    # can be queued per IP (i.e. before nginx starts responding with 503),
+    # and the first 20 requests will be served without any delay. Then, requests
+    # will be delayed according to the rate, and if there's more than 30 queued
+    # total, will receive 503.
+    burst: 30
+    delay: 20
+
 mgmtworker:
   # Sets the logging level to use for the management workers. This affects the
   # logging performed by the manager during the execution of management tasks,


### PR DESCRIPTION
A pretty basic setup of allowing 10 reqs per second per client.

See config.yaml comments for description of the available configuration options.

Execution-token requests are exempt from the rate-limit because we don't want customer's executions to suddenly start failing because their `ctx.logger.info()` spam started receiving 503s...

(And yes, execution-token takes precedence, i.e. if a request contains an invalid execution-token but also a valid authorization header, it's a 401.)