### PR TITLE
pg_hba: use password auth for 'host' connections

### DIFF
--- a/cfy_manager/components/postgresql_server/postgresql_server.py
+++ b/cfy_manager/components/postgresql_server/postgresql_server.py
@@ -316,7 +316,9 @@ class PostgresqlServer(BaseComponent):
         os.close(fd)
         with open(temp_hba_path, 'a') as f:
             for line in lines:
-                if line.startswith(('host', 'local')):
+                if line.startswith('host') and 'trust' in line:
+                    line = line.replace('trust', 'md5')
+                elif line.startswith('local'):
                     line = line.replace('ident', 'md5')
                 f.write(line)
             if not re.search(PG_HBA_HOST_REGEX_PATTERN, '\n'.join(lines))\


### PR DESCRIPTION
This ports #1524 to 7.0.1

Don't ever use 'trust' for host, even for localhost. When using a network conneciton, always use a password