### PR TITLE
RND-1267 utils.files.remove: handle mounted files

### DIFF
--- a/cfy_manager/utils/files.py
+++ b/cfy_manager/utils/files.py
@@ -85,7 +85,7 @@ def remove(paths, ignore_failure=False):
         paths = [paths]
     for path in paths:
         logger.debug('Removing %s...', path)
-        if os.path.ismount(path):
+        if os.path.isdir(path) and os.path.ismount(path):
             logger.debug('Mount point found in %s, deleting contents', path)
             remove(
                 [os.path.join(path, subpath) for subpath in os.listdir(path)],


### PR DESCRIPTION
In containerized environments, ismount might return True for files, depending on the filesystem. So yeah, files can be mounted as well.

The listdir call will fail for files though, so this must be actually only done for mounts that are also directory mounts