### PR TITLE
NE-6426 Add a random suffix to test CA cert name

### DIFF
--- a/cfy_manager/tests/test_certificates.py
+++ b/cfy_manager/tests/test_certificates.py
@@ -167,7 +167,8 @@ def test_generate_ca_cert(tmpdir):
         x509.oid.NameOID.COMMON_NAME)[0].value
     issuer_cn = cert.issuer.get_attributes_for_oid(
         x509.oid.NameOID.COMMON_NAME)[0].value
-    assert subject_cn == issuer_cn == 'Cloudify generated certificate'
+    assert subject_cn.startswith('Cloudify generated certificate')
+    assert issuer_cn.startswith('Cloudify generated certificate')
 
     # check that the cert is marked as a CA
     constraints = cert.extensions.get_extension_for_class(

--- a/cfy_manager/utils/certificates.py
+++ b/cfy_manager/utils/certificates.py
@@ -4,6 +4,7 @@ import itertools
 import json
 import os
 import pwd
+import random
 import string
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -316,6 +317,16 @@ def generate_external_ssl_cert(
     )
 
 
+def _generate_ca_cert_name():
+    # append a random suffix to the CA subject name so that multiple generated
+    # CAs dont have the same name, so that in tests, where we do generate
+    # test CAs many times, we don't hit conflicts.
+    # Note: if multiple CAs of the same subject name are put in a single
+    # CA bundle, only the first matching one is used
+    suffix = ''.join(random.choice(string.ascii_letters) for _ in range(8))
+    return 'Cloudify generated certificate ' + suffix
+
+
 def generate_ca_cert(cert_path=const.CA_CERT_PATH,
                      key_path=const.CA_KEY_PATH):
     key = rsa.generate_private_key(
@@ -325,7 +336,7 @@ def generate_ca_cert(cert_path=const.CA_CERT_PATH,
     subject = issuer = x509.Name([
         x509.NameAttribute(
             x509.oid.NameOID.COMMON_NAME,
-            'Cloudify generated certificate',
+            _generate_ca_cert_name(),
         ),
     ])
 

--- a/jenkins/bp/ec2-manager-install-blueprint.yaml
+++ b/jenkins/bp/ec2-manager-install-blueprint.yaml
@@ -3,7 +3,7 @@ tosca_definitions_version: cloudify_dsl_1_3
 description: >
   This blueprint deploy EC2 for cloudify-manager-install
 imports:
-  - http://cloudify.co/spec/cloudify/7.0.3.dev1/types.yaml
+  - http://cloudify.co/spec/cloudify/6.3.0/types.yaml
   - plugin:cloudify-aws-plugin?version= >=3.0.3
   - plugin:cloudify-utilities-plugin?version= >=1.22.1
 


### PR DESCRIPTION
See the comment. When generating a test CA, let's try to make sure that many created test CAs don't share the name.