### PR TITLE
Change the glibc minor version

### DIFF
--- a/packaging/docker-rh8/Dockerfile
+++ b/packaging/docker-rh8/Dockerfile
@@ -9,14 +9,8 @@ ARG gid=1500
 RUN groupadd -g $gid cfyuser
 RUN useradd -ms /bin/bash -g $gid --home-dir /etc/cloudify -u $uid cfyuser
 
+RUN yum update -y && yum install -y glibc-locale-source glibc-langpack-en
 RUN yum makecache --refresh
-
-RUN yum install -y https://repository.cloudifysource.org/cloudify/components/libnsl-2.28-189.el8.$arch.rpm \
-    https://repository.cloudifysource.org/cloudify/components/glibc-2.28-189.el8.$arch.rpm \
-    https://repository.cloudifysource.org/cloudify/components/glibc-common-2.28-189.el8.$arch.rpm \
-    https://repository.cloudifysource.org/cloudify/components/glibc-langpack-en-2.28-189.el8.$arch.rpm \
-    https://repository.cloudifysource.org/cloudify/components/glibc-minimal-langpack-2.28-189.el8.$arch.rpm \
-    https://repository.cloudifysource.org/cloudify/components/glibc-locale-source-2.28-189.el8.$arch.rpm
 
 RUN yum install -y openssl-1.1.1k libselinux-utils \
     logrotate python3-setuptools which cronie \


### PR DESCRIPTION
Change the way how the glibc langpack and locale-source packages are installed due to issues with building rhel-8 images. 