### PR TITLE
NE-12156 Do not attempt to stop systemd haveged

### DIFF
--- a/cfy_manager/components/haveged/haveged.py
+++ b/cfy_manager/components/haveged/haveged.py
@@ -41,3 +41,9 @@ class Haveged(BaseComponent):
             # We don't manage this
             return
         super().start()
+
+    def stop(self, force=True):
+        if self._using_systemd_haveged():
+            # We don't manage this
+            return
+        super().stop(force)


### PR DESCRIPTION
In case a haveged service is managed by systemd (i.e. not Cloudify/supervisord), do not attempt to stop it using supervisorctl.

---

This is a cherry-pick of https://github.com/cloudify-cosmo/cloudify-manager-install/pull/1547