### PR TITLE
NE-49218 update golang binaries for prometheus and exporters

### DIFF
--- a/packaging/prometheus.spec
+++ b/packaging/prometheus.spec
@@ -1,6 +1,6 @@
 %define _tmpdir /tmp/prometheus
-%define PROMETHEUS_VERSION 2.53.2
-%define _url https://github.com/prometheus/prometheus/releases/download/v%{PROMETHEUS_VERSION}/prometheus-%{PROMETHEUS_VERSION}.linux-%{arch}.tar.gz
+%define PROMETHEUS_VERSION 2.54.1-cloudify-rebuild
+%define _url https://repository.cloudifysource.org/cloudify/components/prometheus-%{PROMETHEUS_VERSION}.linux-%{arch}.tar.gz
 
 # Prevent mangling shebangs (RH8 build default), which fails
 #  with the test files of networkx<2 due to RH8 not having python2.

--- a/packaging/prometheus.spec
+++ b/packaging/prometheus.spec
@@ -1,5 +1,5 @@
 %define _tmpdir /tmp/prometheus
-%define PROMETHEUS_VERSION 2.54.1-cloudify-rebuild
+%define PROMETHEUS_VERSION 2.54.1_cloudify_rebuild
 %define _url https://repository.cloudifysource.org/cloudify/components/prometheus-%{PROMETHEUS_VERSION}.linux-%{arch}.tar.gz
 
 # Prevent mangling shebangs (RH8 build default), which fails

--- a/packaging/prometheus_blackbox_exporter.spec
+++ b/packaging/prometheus_blackbox_exporter.spec
@@ -1,8 +1,8 @@
 %define _tmpdir /tmp/blackbox_exporter
-%define _url https://repository.cloudifysource.org/cloudify/components/blackbox_exporter-0.25.0-cloudify-rebuild.linux-%{arch}.tar.gz
+%define _url https://repository.cloudifysource.org/cloudify/components/blackbox_exporter-0.25.0_cloudify_rebuild.linux-%{arch}.tar.gz
 
 Name:           blackbox_exporter
-Version:        0.25.0-cloudify-rebuild
+Version:        0.25.0_cloudify_rebuild
 Release:        1%{?dist}
 Summary:        Prometheus blackbox_exporter
 Group:          Applications/Multimedia

--- a/packaging/prometheus_blackbox_exporter.spec
+++ b/packaging/prometheus_blackbox_exporter.spec
@@ -1,7 +1,8 @@
 %define _tmpdir /tmp/blackbox_exporter
-%define _url    https://github.com/prometheus/blackbox_exporter/releases/download/v0.24.0/blackbox_exporter-0.24.0.linux-%{arch}.tar.gz
+%define _url https://repository.cloudifysource.org/cloudify/components/blackbox_exporter-0.25.0-cloudify-rebuild.linux-%{arch}.tar.gz
+
 Name:           blackbox_exporter
-Version:        0.24.0
+Version:        0.25.0-cloudify-rebuild
 Release:        1%{?dist}
 Summary:        Prometheus blackbox_exporter
 Group:          Applications/Multimedia

--- a/packaging/prometheus_node_exporter.spec
+++ b/packaging/prometheus_node_exporter.spec
@@ -1,5 +1,5 @@
 %define _tmpdir /tmp/node_exporter
-%define NODE_EXPORTER_VERSION 1.8.2-cloudify-rebuild
+%define NODE_EXPORTER_VERSION 1.8.2_cloudify_rebuild
 %define _url https://repository.cloudifysource.org/cloudify/components/node_exporter-%{NODE_EXPORTER_VERSION}.linux-%{arch}.tar.gz
 
 Name:           node_exporter

--- a/packaging/prometheus_node_exporter.spec
+++ b/packaging/prometheus_node_exporter.spec
@@ -1,6 +1,7 @@
 %define _tmpdir /tmp/node_exporter
-%define NODE_EXPORTER_VERSION 1.8.2
-%define _url    https://github.com/prometheus/node_exporter/releases/download/v%{NODE_EXPORTER_VERSION}/node_exporter-%{NODE_EXPORTER_VERSION}.linux-%{arch}.tar.gz
+%define NODE_EXPORTER_VERSION 1.8.2-cloudify-rebuild
+%define _url https://repository.cloudifysource.org/cloudify/components/node_exporter-%{NODE_EXPORTER_VERSION}.linux-%{arch}.tar.gz
+
 Name:           node_exporter
 Version:        %{NODE_EXPORTER_VERSION}
 Release:        1%{?dist}

--- a/packaging/prometheus_postgres_exporter.spec
+++ b/packaging/prometheus_postgres_exporter.spec
@@ -1,8 +1,8 @@
 %define _tmpdir /tmp/postgres_exporter
-%define _url https://repository.cloudifysource.org/cloudify/components/postgres_exporter-0.15.0-cloudify-rebuild.linux-%{arch}.tar.gz
+%define _url https://repository.cloudifysource.org/cloudify/components/postgres_exporter-0.15.0_cloudify_rebuild.linux-%{arch}.tar.gz
 
 Name:           postgres_exporter
-Version:        0.15.0-cloudify-rebuild
+Version:        0.15.0_cloudify_rebuild
 Release:        1%{?dist}
 Summary:        Prometheus postgres_exporter
 Group:          Applications/Multimedia

--- a/packaging/prometheus_postgres_exporter.spec
+++ b/packaging/prometheus_postgres_exporter.spec
@@ -1,7 +1,8 @@
 %define _tmpdir /tmp/postgres_exporter
-%define _url    https://github.com/prometheus-community/postgres_exporter/releases/download/v0.15.0/postgres_exporter-0.15.0.linux-%{arch}.tar.gz
+%define _url https://repository.cloudifysource.org/cloudify/components/postgres_exporter-0.15.0-cloudify-rebuild.linux-%{arch}.tar.gz
+
 Name:           postgres_exporter
-Version:        0.15.0
+Version:        0.15.0-cloudify-rebuild
 Release:        1%{?dist}
 Summary:        Prometheus postgres_exporter
 Group:          Applications/Multimedia


### PR DESCRIPTION
The following packages were recompiled with golang 1.23.2 and replaced:
- postgres-exporter (no version change)
- node-exporter (no version change)
- blackbox-exporter (update to 0.25.0)
- prometheus and promtool (update to 2.54.1, update docker library to 27.2.0)